### PR TITLE
Fix #10 by automatically setting rename_rule to snake_case for enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,4 +5,4 @@
 - Added support for returning multiple errors from parsing [#5](https://github.com/TedDriggs/darling/pull/5)
 - Derived impls no longer return on first error [#5](https://github.com/TedDriggs/darling/pull/5)
 - Removed default types for `V` and `F` from `ast::Body`
-- Enum variants are automatically converted to snake_case
+- Enum variants are automatically converted to snake_case [#12](https://github.com/TedDriggs/darling/pull/12)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 - Added support for returning multiple errors from parsing [#5](https://github.com/TedDriggs/darling/pull/5)
 - Derived impls no longer return on first error [#5](https://github.com/TedDriggs/darling/pull/5)
 - Removed default types for `V` and `F` from `ast::Body`
+- Enum variants are automatically converted to snake_case

--- a/tests/accrue_errors.rs
+++ b/tests/accrue_errors.rs
@@ -60,7 +60,6 @@ fn body_only_issues() {
 }
 
 #[derive(Debug, FromMetaItem)]
-#[darling(rename_all="snake_case")]
 enum Week {
     Monday,
     Tuesday {


### PR DESCRIPTION
When deriving for an enum, assume the author wants snake_case unless explicitly set otherwise.