### PR TITLE
Rename "magic" fields for struct and variant data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,15 @@
 
 ## Unreleased Changes
 
+### Breaking Changes
+- Update `syn` to 0.12 [#20](https://github.com/TedDriggs/darling/pull/20). Thanks to @Eijebong
+- Update `quote` to 0.4 [#20](https://github.com/TedDriggs/darling/pull/20). Thanks to @Eijebong
+- Rename magic field `body` in derived `FromDeriveInput` structs to `data` to stay in sync with `syn`
+- Rename magic field `data` in derived `FromVariant` structs to `fields` to stay in sync with `syn`
+
 ## v0.2.2 (December 5, 2017)
 
-- Update `lazy_static` to 1.0 [#15](https://github.com/TedDriggs/darling/pull/16). Thanks to @Ejiebong
+- Update `lazy_static` to 1.0 [#15](https://github.com/TedDriggs/darling/pull/16). Thanks to @Eijebong
 
 ## v0.2.1 (November 28, 2017)
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Darling's features are built to work well for real-world projects.
 
 * **Defaults**: Supports struct- and field-level defaults, using the same path syntax as `serde`.
 * **Field Renaming**: Fields can have different names in usage vs. the backing code.
-* **Auto-populated fields**: Structs deriving `FromDeriveInput` and `FromField` can declare properties named `ident`, `vis`, `ty`, `attrs`, and `generics` to automatically get copies of the matching values from the input AST.
+* **Auto-populated fields**: Structs deriving `FromDeriveInput` and `FromField` can declare properties named `ident`, `vis`, `ty`, `attrs`, and `generics` to automatically get copies of the matching values from the input AST. `FromDeriveInput` additionally exposes `data` to get access to the body of the deriving type, and `FromVariant` exposes `fields`.
 * **Mapping function**: Use `#[darling(map="path")]` to specify a function that runs on the result of parsing a meta-item field. This can change the return type, which enables you to parse to an intermediate form and convert that to the type you need in your struct.
 * **Skip fields**: Use `#[darling(skip)]` to mark a field that shouldn't be read from attribute meta-items.
 * **Multiple-occurrence fields**: Use `#[darling(multiple)]` on a `Vec` field to allow that field to appear multiple times in the meta-item. Each occurrence will be pushed into the `Vec`.

--- a/core/src/codegen/fmi_impl.rs
+++ b/core/src/codegen/fmi_impl.rs
@@ -12,7 +12,7 @@ impl<'a> ToTokens for FmiImpl<'a> {
     fn to_tokens(&self, tokens: &mut Tokens) {
         let base = &self.base;
 
-        let impl_block = match base.body {
+        let impl_block = match base.data {
             // Unit structs allow empty bodies only.
             Data::Struct(ref vd) if vd.style.is_unit() => {
                 let ty_ident = base.ident;

--- a/core/src/codegen/from_derive_impl.rs
+++ b/core/src/codegen/from_derive_impl.rs
@@ -10,7 +10,7 @@ pub struct FromDeriveInputImpl<'a> {
     pub generics: Option<&'a Ident>,
     pub vis: Option<&'a Ident>,
     pub attrs: Option<&'a Ident>,
-    pub body: Option<&'a Ident>,
+    pub data: Option<&'a Ident>,
     pub base: TraitImpl<'a>,
     pub attr_names: Vec<&'a str>,
     pub forward_attrs: Option<&'a ForwardAttrs>,
@@ -24,7 +24,7 @@ impl<'a> ToTokens for FromDeriveInputImpl<'a> {
         let input = self.param_name();
         let map = self.base.map_fn();
 
-        if let Data::Struct(ref data) = self.base.body {
+        if let Data::Struct(ref data) = self.base.data {
             if data.is_newtype() {
                 self.wrap(quote!{
                     fn from_derive_input(#input: &::syn::DeriveInput) -> ::darling::Result<Self> {
@@ -42,7 +42,7 @@ impl<'a> ToTokens for FromDeriveInputImpl<'a> {
         let passed_vis = self.vis.as_ref().map(|i| quote!(#i: #input.vis.clone(),));
         let passed_generics = self.generics.as_ref().map(|i| quote!(#i: #input.generics.clone(),));
         let passed_attrs = self.attrs.as_ref().map(|i| quote!(#i: __fwd_attrs,));
-        let passed_body = self.body.as_ref().map(|i| quote!(#i: ::darling::ast::Data::try_from(&#input.data)?,));
+        let passed_body = self.data.as_ref().map(|i| quote!(#i: ::darling::ast::Data::try_from(&#input.data)?,));
 
         let supports = self.supports.map(|i| quote!{
             #i

--- a/core/src/codegen/from_variant_impl.rs
+++ b/core/src/codegen/from_variant_impl.rs
@@ -7,7 +7,7 @@ use options::{DataShape, ForwardAttrs};
 pub struct FromVariantImpl<'a> {
     pub base: TraitImpl<'a>,
     pub ident: Option<&'a Ident>,
-    pub data: Option<&'a Ident>,
+    pub fields: Option<&'a Ident>,
     pub attrs: Option<&'a Ident>,
     pub attr_names: Vec<&'a str>,
     pub forward_attrs: Option<&'a ForwardAttrs>,
@@ -21,7 +21,7 @@ impl<'a> ToTokens for FromVariantImpl<'a> {
         let extractor = self.extractor();
         let passed_ident = self.ident.as_ref().map(|i| quote!(#i: #input.ident.clone(),));
         let passed_attrs = self.attrs.as_ref().map(|i| quote!(#i: __fwd_attrs,));
-        let passed_data = self.data.as_ref().map(|i| quote!(#i: ::darling::ast::Fields::try_from(&#input.fields)?,));
+        let passed_fields = self.fields.as_ref().map(|i| quote!(#i: ::darling::ast::Fields::try_from(&#input.fields)?,));
 
         let inits = self.base.initializers();
         let map = self.base.map_fn();
@@ -58,7 +58,7 @@ impl<'a> ToTokens for FromVariantImpl<'a> {
                 ::darling::export::Ok(Self {
                     #passed_ident
                     #passed_attrs
-                    #passed_data
+                    #passed_fields
                     #inits
                 }) #map
             }

--- a/core/src/codegen/trait_impl.rs
+++ b/core/src/codegen/trait_impl.rs
@@ -10,7 +10,7 @@ use ast::Data;
 pub struct TraitImpl<'a> {
     pub ident: &'a Ident,
     pub generics: &'a Generics,
-    pub body: Data<Variant<'a>, Field<'a>>,
+    pub data: Data<Variant<'a>, Field<'a>>,
     pub default: Option<DefaultExpression<'a>>,
     pub map: Option<&'a Path>,
     pub bound: Option<&'a [WherePredicate]>,
@@ -29,7 +29,7 @@ impl<'a> TraitImpl<'a> {
 
     /// Generate local variable declarations for all fields.
     pub(in codegen) fn local_declarations(&self) -> Tokens {
-        if let Data::Struct(ref vd) = self.body {
+        if let Data::Struct(ref vd) = self.data {
             let vdr = vd.as_ref().map(Field::as_declaration);
             let decls = vdr.fields.as_slice();
             quote!(#(#decls)*)
@@ -40,7 +40,7 @@ impl<'a> TraitImpl<'a> {
 
     /// Generate immutable variable declarations for all fields.
     pub(in codegen) fn immutable_declarations(&self) -> Tokens {
-        if let Data::Struct(ref vd) = self.body {
+        if let Data::Struct(ref vd) = self.data {
             let vdr = vd.as_ref().map(|f| field::Declaration::new(f, false));
             let decls = vdr.fields.as_slice();
             quote!(#(#decls)*)
@@ -60,7 +60,7 @@ impl<'a> TraitImpl<'a> {
     }
 
     pub fn require_fields(&self) -> Tokens {
-        if let Data::Struct(ref vd) = self.body {
+        if let Data::Struct(ref vd) = self.data {
             let check_nones = vd.as_ref().map(Field::as_presence_check);
             let checks = check_nones.fields.as_slice();
             quote!(#(#checks)*)
@@ -70,7 +70,7 @@ impl<'a> TraitImpl<'a> {
     }
 
     pub(in codegen) fn initializers(&self) -> Tokens {
-        let foo = match self.body {
+        let foo = match self.data {
             Data::Enum(_) => panic!("Core loop on enums isn't supported"),
             Data::Struct(ref data) => {
                 FieldsGen(data)
@@ -82,7 +82,7 @@ impl<'a> TraitImpl<'a> {
 
     /// Generate the loop which walks meta items looking for property matches.
     pub(in codegen) fn core_loop(&self) -> Tokens {
-        let foo = match self.body {
+        let foo = match self.data {
             Data::Enum(_) => panic!("Core loop on enums isn't supported"),
             Data::Struct(ref data) => {
                 FieldsGen(data)

--- a/core/src/options/core.rs
+++ b/core/src/options/core.rs
@@ -29,7 +29,7 @@ pub struct Core {
     pub map: Option<syn::Path>,
 
     /// The body of the _deriving_ type.
-    pub body: Data<InputVariant, InputField>,
+    pub data: Data<InputVariant, InputField>,
 
     /// The custom bound to apply to the generated impl
     pub bound: Option<Vec<syn::WherePredicate>>,
@@ -41,7 +41,7 @@ impl Core {
         Core {
             ident: di.ident.clone(),
             generics: di.generics.clone(),
-            body: Data::empty_from(&di.data),
+            data: Data::empty_from(&di.data),
             default: Default::default(),
             // See https://github.com/TedDriggs/darling/issues/10: We default to snake_case
             // for enums to help authors produce more idiomatic APIs.
@@ -104,7 +104,7 @@ impl ParseData for Core {
     fn parse_variant(&mut self, variant: &syn::Variant) -> Result<()> {
         let v = InputVariant::from_variant(variant, Some(&self))?;
 
-        match self.body {
+        match self.data {
             Data::Enum(ref mut variants) => {
                 variants.push(v);
                 Ok(())
@@ -116,7 +116,7 @@ impl ParseData for Core {
     fn parse_field(&mut self, field: &syn::Field) -> Result<()> {
         let f = InputField::from_field(field, Some(&self))?;
 
-        match self.body {
+        match self.data {
             Data::Struct(Fields { style: Style::Unit, .. }) => {
                 panic!("Core::parse_field should not be called on unit")
             }
@@ -134,7 +134,7 @@ impl<'a> From<&'a Core> for codegen::TraitImpl<'a> {
         codegen::TraitImpl {
             ident: &v.ident,
             generics: &v.generics,
-            body: v.body
+            data: v.data
                 .as_ref()
                 .map_struct_fields(InputField::as_codegen_field)
                 .map_enum_variants(|variant| variant.as_codegen_variant(&v.ident)),

--- a/core/src/options/from_derive.rs
+++ b/core/src/options/from_derive.rs
@@ -14,7 +14,7 @@ pub struct FdiOptions {
     /// The field on the target struct which should receive the type generics, if any.
     pub generics: Option<Ident>,
 
-    pub body: Option<Ident>,
+    pub data: Option<Ident>,
 
     pub supports: Option<Shape>,
 }
@@ -25,7 +25,7 @@ impl FdiOptions {
             base: OuterFrom::start(di),
             vis: Default::default(),
             generics: Default::default(),
-            body: Default::default(),
+            data: Default::default(),
             supports: Default::default(),
         }).parse_attributes(&di.attrs)?.parse_body(&di.data)
     }
@@ -48,7 +48,7 @@ impl ParseData for FdiOptions {
     fn parse_field(&mut self, field: &syn::Field) -> Result<()> {
         match field.ident.as_ref().map(|v| v.as_ref()) {
             Some("vis") => { self.vis = field.ident.clone(); Ok(()) }
-            Some("body") => { self.body = field.ident.clone(); Ok(()) }
+            Some("data") => { self.data = field.ident.clone(); Ok(()) }
             Some("generics") => { self.generics = field.ident.clone(); Ok(()) }
             _ => self.base.parse_field(field)
         }
@@ -63,7 +63,7 @@ impl<'a> From<&'a FdiOptions> for codegen::FromDeriveInputImpl<'a> {
             from_ident: Some(v.base.from_ident),
             ident: v.base.ident.as_ref(),
             vis: v.vis.as_ref(),
-            body: v.body.as_ref(),
+            data: v.data.as_ref(),
             generics: v.generics.as_ref(),
             attrs: v.base.attrs.as_ref(),
             forward_attrs: v.base.forward_attrs.as_ref(),

--- a/core/src/options/from_variant.rs
+++ b/core/src/options/from_variant.rs
@@ -7,7 +7,7 @@ use options::{OuterFrom, ParseAttribute, ParseData, DataShape};
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FromVariantOptions {
     pub base: OuterFrom,
-    pub data: Option<Ident>,
+    pub fields: Option<Ident>,
     pub supports: Option<DataShape>,
 }
 
@@ -15,7 +15,7 @@ impl FromVariantOptions {
     pub fn new(di: &DeriveInput) -> Result<Self> {
         (FromVariantOptions {
             base: OuterFrom::start(di),
-            data: Default::default(),
+            fields: Default::default(),
             supports: Default::default(),
         }).parse_attributes(&di.attrs)?.parse_body(&di.data)
     }
@@ -26,7 +26,7 @@ impl<'a> From<&'a FromVariantOptions> for FromVariantImpl<'a> {
         FromVariantImpl {
             base: (&v.base.container).into(),
             ident: v.base.ident.as_ref(),
-            data: v.data.as_ref(),
+            fields: v.fields.as_ref(),
             attrs: v.base.attrs.as_ref(),
             attr_names: v.base.attr_names.as_strs(),
             forward_attrs: v.base.forward_attrs.as_ref(),
@@ -48,7 +48,7 @@ impl ParseAttribute for FromVariantOptions {
 impl ParseData for FromVariantOptions {
     fn parse_field(&mut self, field: &Field) -> Result<()> {
         match field.ident.as_ref().map(|i| i.as_ref()) {
-            Some("data") => { self.data = field.ident.clone(); Ok(()) }
+            Some("fields") => { self.fields = field.ident.clone(); Ok(()) }
             _ => self.base.parse_field(field)
         }
     }

--- a/tests/accrue_errors.rs
+++ b/tests/accrue_errors.rs
@@ -13,7 +13,7 @@ use darling::FromDeriveInput;
 struct Lorem {
     ipsum: String,
     dolor: Dolor,
-    body: ast::Data<(), LoremField>,
+    data: ast::Data<(), LoremField>,
 }
 
 #[derive(Debug, FromMetaItem)]

--- a/tests/from_variant.rs
+++ b/tests/from_variant.rs
@@ -9,7 +9,7 @@ pub struct Lorem {
     ident: syn::Ident,
     into: Option<bool>,
     skip: Option<bool>,
-    data: darling::ast::Fields<syn::Type>,
+    fields: darling::ast::Fields<syn::Type>,
 }
 
 impl From<syn::Ident> for Lorem {
@@ -18,12 +18,12 @@ impl From<syn::Ident> for Lorem {
             ident,
             into: Default::default(),
             skip: Default::default(),
-            data: darling::ast::Style::Unit.into(),
+            fields: darling::ast::Style::Unit.into(),
         }
     }
 }
 
 #[test]
 fn expansion() {
-    
+
 }

--- a/tests/supports.rs
+++ b/tests/supports.rs
@@ -8,7 +8,7 @@ use darling::FromDeriveInput;
 #[derive(Debug,FromDeriveInput)]
 #[darling(attributes(from_variants), supports(enum_any))]
 pub struct Container {
-    body: ast::Data<Variant, ()>,
+    data: ast::Data<Variant, ()>,
 }
 
 #[derive(Default, Debug, FromVariant)]


### PR DESCRIPTION
The names now align once again with syn's names for the same fields.