### PR TITLE
Support proc-macro2/nightly

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,4 +17,5 @@ default = ["syn/full"]
 [dependencies]
 ident_case = "1.0.0"
 syn = { version = "0.12.10", features = ["extra-traits"] }
+proc-macro2 = "0.2"
 quote = "0.4"

--- a/core/src/codegen/default_expr.rs
+++ b/core/src/codegen/default_expr.rs
@@ -24,7 +24,7 @@ impl<'a> ToTokens for DefaultExpression<'a> {
     fn to_tokens(&self, tokens: &mut Tokens) {
         tokens.append_all(match *self {
             DefaultExpression::Inherit(ident) => {
-                let dsn = Ident::from(DEFAULT_STRUCT_NAME);
+                let dsn = Ident::new(DEFAULT_STRUCT_NAME, ::proc_macro2::Span::call_site());
                 quote!(#dsn.#ident)
             },
             DefaultExpression::Explicit(path) => quote!(#path()),
@@ -38,7 +38,7 @@ pub struct DefaultDeclaration<'a>(&'a DefaultExpression<'a>);
 
 impl<'a> ToTokens for DefaultDeclaration<'a> {
     fn to_tokens(&self, tokens: &mut Tokens) {
-        let name = Ident::from(DEFAULT_STRUCT_NAME);
+        let name = Ident::new(DEFAULT_STRUCT_NAME, ::proc_macro2::Span::call_site());
         let expr = self.0;
         tokens.append_all(quote!(let #name: Self = #expr;));
     }

--- a/core/src/from_meta_item.rs
+++ b/core/src/from_meta_item.rs
@@ -192,7 +192,7 @@ impl FromMetaItem for isize {
 
 impl FromMetaItem for syn::Ident {
     fn from_string(value: &str) -> Result<Self> {
-        Ok(syn::Ident::from(value))
+        Ok(syn::Ident::new(value, ::proc_macro2::Span::call_site()))
     }
 }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -5,6 +5,7 @@ extern crate quote;
 
 #[macro_use]
 extern crate syn;
+extern crate proc_macro2;
 
 extern crate ident_case;
 

--- a/core/src/macros.rs
+++ b/core/src/macros.rs
@@ -1,3 +1,9 @@
+macro_rules! quote {
+    ($($tt:tt)*) => {
+        quote_spanned!(::proc_macro2::Span::call_site() => $($tt)*)
+    };
+}
+
 macro_rules! path {
     ($($path:tt)+) => {
         parse_quote!($($path)+)

--- a/core/src/options/input_field.rs
+++ b/core/src/options/input_field.rs
@@ -61,7 +61,7 @@ impl InputField {
     }
 
     pub fn from_field(f: &syn::Field, parent: Option<&Core>) -> Result<Self> {
-        let ident = f.ident.clone().unwrap_or(syn::Ident::from("__unnamed"));
+        let ident = f.ident.clone().unwrap_or(syn::Ident::new("__unnamed", ::proc_macro2::Span::call_site()));
         let ty = f.ty.clone();
         let base = Self::new(ident, ty).parse_attributes(&f.attrs)?;
 


### PR DESCRIPTION
Fixes #23.

`::darling` style paths only works with `Span::call_site()`.

Note that tests fails with `proc_macro::__internal::with_sess() called before set_parse_sess()!` if `proc- macro2/nightly` is enabled because `proc_macro`'s apis cannot be called from non-proc-macro code.