### PR TITLE
Have From{Derive,Variant}::from_ident not Option.

### DIFF
--- a/core/src/codegen/from_derive_impl.rs
+++ b/core/src/codegen/from_derive_impl.rs
@@ -14,7 +14,7 @@ pub struct FromDeriveInputImpl<'a> {
     pub base: TraitImpl<'a>,
     pub attr_names: Vec<&'a str>,
     pub forward_attrs: Option<&'a ForwardAttrs>,
-    pub from_ident: Option<bool>,
+    pub from_ident: bool,
     pub supports: Option<&'a Shape>,
 }
 
@@ -50,7 +50,7 @@ impl<'a> ToTokens for FromDeriveInputImpl<'a> {
         });
 
         let inits = self.base.initializers();
-        let default = if let Some(true) = self.from_ident {
+        let default = if self.from_ident {
             quote!(let __default: Self = ::darling::export::From::from(#input.ident.clone());)
         } else {
             self.base.fallback_decl()

--- a/core/src/codegen/from_variant_impl.rs
+++ b/core/src/codegen/from_variant_impl.rs
@@ -11,7 +11,7 @@ pub struct FromVariantImpl<'a> {
     pub attrs: Option<&'a Ident>,
     pub attr_names: Vec<&'a str>,
     pub forward_attrs: Option<&'a ForwardAttrs>,
-    pub from_ident: Option<bool>,
+    pub from_ident: bool,
     pub supports: Option<&'a DataShape>,
 }
 
@@ -26,7 +26,7 @@ impl<'a> ToTokens for FromVariantImpl<'a> {
         let inits = self.base.initializers();
         let map = self.base.map_fn();
 
-        let default = if let Some(true) = self.from_ident {
+        let default = if self.from_ident {
             quote!(let __default: Self = ::darling::export::From::from(#input.ident.clone());)
         } else {
             self.base.fallback_decl()

--- a/core/src/options/from_derive.rs
+++ b/core/src/options/from_derive.rs
@@ -60,7 +60,7 @@ impl<'a> From<&'a FdiOptions> for codegen::FromDeriveInputImpl<'a> {
         codegen::FromDeriveInputImpl {
             base: (&v.base.container).into(),
             attr_names: v.base.attr_names.as_strs(),
-            from_ident: Some(v.base.from_ident),
+            from_ident: v.base.from_ident,
             ident: v.base.ident.as_ref(),
             vis: v.vis.as_ref(),
             data: v.data.as_ref(),

--- a/core/src/options/from_variant.rs
+++ b/core/src/options/from_variant.rs
@@ -30,7 +30,7 @@ impl<'a> From<&'a FromVariantOptions> for FromVariantImpl<'a> {
             attrs: v.base.attrs.as_ref(),
             attr_names: v.base.attr_names.as_strs(),
             forward_attrs: v.base.forward_attrs.as_ref(),
-            from_ident: Some(v.base.from_ident),
+            from_ident: v.base.from_ident,
             supports: v.supports.as_ref(),
         }
     }


### PR DESCRIPTION
`From{Derive,Variant}` only have one place each initializes them, and both places use `Some` on `from_ident`, so it seems unnecessary to use `Option<bool>` on them.