### PR TITLE
Implement FromGenerics et al

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog
 
 ## Unreleased Features
-- Add `FromGenerics` trait
+- Add `ast::Generics` and `ast::GenericParam` to work with generics in a manner similar to `ast::Data`
+- Add `ast::GenericParamExt` to support alternate representations of generic parameters
+- Add `util::WithOriginal` to get a parsed representation and syn's own struct for a syntax block
+- Add `FromGenerics` and `FromGenericParam` traits (without derive support)
+- Change generated code for `generics` magic field to invoke `FromGenerics` trait during parsing
 - Add `FromTypeParam` trait [#30](https://github.com/TedDriggs/darling/pull/30). Thanks to @upsuper
 
 ## v0.4.0 (April 5, 2018)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## Unreleased Features
-_None_
+- Add `FromGenerics` trait
+- Add `FromTypeParam` trait [#30](https://github.com/TedDriggs/darling/pull/30). Thanks to @upsuper
 
 ## v0.4.0 (April 5, 2018)
 - Update dependencies on `proc-macro`, `quote`, and `syn` [#26](https://github.com/TedDriggs/darling/pull/26). Thanks to @hcpl

--- a/core/src/ast.rs
+++ b/core/src/ast.rs
@@ -2,9 +2,9 @@
 
 use syn;
 
-use {Error, FromField, FromVariant, Result};
+use {Error, FromField, FromTypeParam, FromVariant, Result};
 
-/// A struct or enum body. 
+/// A struct or enum body.
 ///
 /// `V` is the type which receives any encountered variants, and `F` receives struct fields.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -286,5 +286,19 @@ impl<'a> From<&'a syn::Fields> for Style {
             syn::Fields::Unnamed(_) => Style::Tuple,
             syn::Fields::Unit => Style::Unit,
         }
+    }
+}
+
+pub struct Generics<P, W = syn::WhereClause> {
+    pub params: Vec<P>,
+    pub where_clause: Option<W>,
+}
+
+impl<P: FromTypeParam> Generics<P, syn::WhereClause> {
+    pub fn try_from(generics: &syn::Generics) -> Result<Self> {
+        Ok(Generics {
+            params: generics.type_params().map(FromTypeParam::from_type_param).collect::<Result<Vec<P>>>()?,
+            where_clause: generics.where_clause.clone(),
+        })
     }
 }

--- a/core/src/ast/generics.rs
+++ b/core/src/ast/generics.rs
@@ -47,6 +47,22 @@ impl GenericParamExt for syn::GenericParam {
             None
         }
     }
+
+    fn as_lifetime_def(&self) -> Option<&Self::LifetimeDef> {
+        if let syn::GenericParam::Lifetime(ref val) = *self {
+            Some(val)
+        } else {
+            None
+        }
+    }
+
+    fn as_const_param(&self) -> Option<&Self::ConstParam> {
+        if let syn::GenericParam::Const(ref val) = *self {
+            Some(val)
+        } else {
+            None
+        }
+    }
 }
 
 impl GenericParamExt for syn::TypeParam {
@@ -59,6 +75,7 @@ impl GenericParamExt for syn::TypeParam {
     }
 }
 
+/// A mirror of `syn::GenericParam` which is generic over all its contents.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GenericParam<T = syn::TypeParam, L = syn::LifetimeDef, C = syn::ConstParam> {
     Type(T),
@@ -119,7 +136,7 @@ impl<T, L, C> GenericParamExt for GenericParam<T, L, C> {
 /// A mirror of the `syn::Generics` type which can contain arbitrary representations
 /// of params and where clauses.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Generics<P = syn::GenericParam, W = syn::WhereClause> {
+pub struct Generics<P, W = syn::WhereClause> {
     pub params: Vec<P>,
     pub where_clause: Option<W>,
 }

--- a/core/src/ast/generics.rs
+++ b/core/src/ast/generics.rs
@@ -1,0 +1,177 @@
+//! Types for working with generics
+
+use std::iter::Iterator;
+use std::slice::Iter;
+
+use syn;
+
+use {FromGenericParam, FromGenerics, FromTypeParam, Result};
+
+/// Extension trait for `GenericParam` to support getting values by variant.
+///
+/// # Usage
+/// `darling::ast::Generics` needs a way to test its params array in order to iterate over type params.
+/// Rather than require callers to use `darling::ast::GenericParam` in all cases, this trait makes that
+/// polymorphic.
+pub trait GenericParamExt {
+    /// The type this GenericParam uses to represent type params and their bounds
+    type TypeParam;
+    type LifetimeDef;
+    type ConstParam;
+
+    /// If this GenericParam is a type param, get the underlying value.
+    fn as_type_param(&self) -> Option<&Self::TypeParam> {
+        None
+    }
+
+    /// If this GenericParam is a lifetime, get the underlying value.
+    fn as_lifetime_def(&self) -> Option<&Self::LifetimeDef> {
+        None
+    }
+
+    /// If this GenericParam is a const param, get the underlying value.
+    fn as_const_param(&self) -> Option<&Self::ConstParam> {
+        None
+    }
+}
+
+impl GenericParamExt for syn::GenericParam {
+    type TypeParam = syn::TypeParam;
+    type LifetimeDef = syn::LifetimeDef;
+    type ConstParam = syn::ConstParam;
+
+    fn as_type_param(&self) -> Option<&Self::TypeParam> {
+        if let syn::GenericParam::Type(ref val) = *self {
+            Some(val)
+        } else {
+            None
+        }
+    }
+}
+
+impl GenericParamExt for syn::TypeParam {
+    type TypeParam = syn::TypeParam;
+    type LifetimeDef = ();
+    type ConstParam = ();
+
+    fn as_type_param(&self) -> Option<&Self::TypeParam> {
+        Some(self)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum GenericParam<T = syn::TypeParam, L = syn::LifetimeDef, C = syn::ConstParam> {
+    Type(T),
+    Lifetime(L),
+    Const(C),
+}
+
+impl<T: FromTypeParam> FromTypeParam for GenericParam<T> {
+    fn from_type_param(type_param: &syn::TypeParam) -> Result<Self> {
+        Ok(GenericParam::Type(FromTypeParam::from_type_param(
+            type_param,
+        )?))
+    }
+}
+
+impl<T: FromTypeParam> FromGenericParam for GenericParam<T> {
+    fn from_generic_param(param: &syn::GenericParam) -> Result<Self> {
+        Ok(match *param {
+            syn::GenericParam::Type(ref ty) => {
+                GenericParam::Type(FromTypeParam::from_type_param(ty)?)
+            }
+            syn::GenericParam::Lifetime(ref val) => GenericParam::Lifetime(val.clone()),
+            syn::GenericParam::Const(ref val) => GenericParam::Const(val.clone()),
+        })
+    }
+}
+
+impl<T, L, C> GenericParamExt for GenericParam<T, L, C> {
+    type TypeParam = T;
+    type LifetimeDef = L;
+    type ConstParam = C;
+
+    fn as_type_param(&self) -> Option<&T> {
+        if let GenericParam::Type(ref val) = *self {
+            Some(val)
+        } else {
+            None
+        }
+    }
+
+    fn as_lifetime_def(&self) -> Option<&L> {
+        if let GenericParam::Lifetime(ref val) = *self {
+            Some(val)
+        } else {
+            None
+        }
+    }
+
+    fn as_const_param(&self) -> Option<&C> {
+        if let GenericParam::Const(ref val) = *self {
+            Some(val)
+        } else {
+            None
+        }
+    }
+}
+
+/// A mirror of the `syn::Generics` type which can contain arbitrary representations
+/// of params and where clauses.
+#[derive(Debug, Clone)]
+pub struct Generics<P = syn::GenericParam, W = syn::WhereClause> {
+    pub params: Vec<P>,
+    pub where_clause: Option<W>,
+}
+
+impl<P, W> Generics<P, W> {
+    pub fn type_params<'a>(&'a self) -> TypeParams<'a, P> {
+        TypeParams(self.params.iter())
+    }
+}
+
+impl<P: FromGenericParam> FromGenerics for Generics<P> {
+    fn from_generics(generics: &syn::Generics) -> Result<Self> {
+        Ok(Generics {
+            params: generics
+                .params
+                .iter()
+                .map(FromGenericParam::from_generic_param)
+                .collect::<Result<Vec<P>>>()?,
+            where_clause: generics.where_clause.clone(),
+        })
+    }
+}
+
+pub struct TypeParams<'a, P: 'a>(Iter<'a, P>);
+
+impl<'a, P: GenericParamExt> Iterator for TypeParams<'a, P> {
+    type Item = &'a <P as GenericParamExt>::TypeParam;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let next = self.0.next();
+        match next {
+            None => None,
+            Some(v) => match v.as_type_param() {
+                Some(val) => Some(val),
+                None => self.next(),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use syn;
+
+    use super::{GenericParam, Generics};
+    use FromGenerics;
+
+    #[test]
+    fn generics() {
+        let g: syn::Generics = parse_quote!(<T>);
+        let deified: Generics<GenericParam<syn::Ident>> = FromGenerics::from_generics(&g).unwrap();
+        assert!(deified.params.len() == 1);
+        assert!(deified.where_clause.is_none());
+    }
+}

--- a/core/src/ast/generics.rs
+++ b/core/src/ast/generics.rs
@@ -59,7 +59,7 @@ impl GenericParamExt for syn::TypeParam {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GenericParam<T = syn::TypeParam, L = syn::LifetimeDef, C = syn::ConstParam> {
     Type(T),
     Lifetime(L),
@@ -118,7 +118,7 @@ impl<T, L, C> GenericParamExt for GenericParam<T, L, C> {
 
 /// A mirror of the `syn::Generics` type which can contain arbitrary representations
 /// of params and where clauses.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Generics<P = syn::GenericParam, W = syn::WhereClause> {
     pub params: Vec<P>,
     pub where_clause: Option<W>,

--- a/core/src/ast/mod.rs
+++ b/core/src/ast/mod.rs
@@ -2,7 +2,11 @@
 
 use syn;
 
-use {Error, FromField, FromTypeParam, FromVariant, Result};
+use {Error, FromField, FromVariant, Result};
+
+mod generics;
+
+pub use self::generics::{GenericParam, GenericParamExt, Generics};
 
 /// A struct or enum body.
 ///
@@ -13,7 +17,7 @@ pub enum Data<V, F> {
     Struct(Fields<F>),
 }
 
-#[deprecated(since="0.3", note="this has been renamed to Data")]
+#[deprecated(since = "0.3", note = "this has been renamed to Data")]
 pub type Body<V, F> = Data<V, F>;
 
 impl<V, F> Data<V, F> {
@@ -36,7 +40,8 @@ impl<V, F> Data<V, F> {
 
     /// Applies a function `V -> U` on enum variants, if this is an enum.
     pub fn map_enum_variants<T, U>(self, map: T) -> Data<U, F>
-        where T: FnMut(V) -> U
+    where
+        T: FnMut(V) -> U,
     {
         match self {
             Data::Enum(v) => Data::Enum(v.into_iter().map(map).collect()),
@@ -46,7 +51,8 @@ impl<V, F> Data<V, F> {
 
     /// Applies a function `F -> U` on struct fields, if this is a struct.
     pub fn map_struct_fields<T, U>(self, map: T) -> Data<V, U>
-        where T: FnMut(F) -> U
+    where
+        T: FnMut(F) -> U,
     {
         match self {
             Data::Enum(v) => Data::Enum(v),
@@ -56,7 +62,8 @@ impl<V, F> Data<V, F> {
 
     /// Applies a function to the `Fields` if this is a struct.
     pub fn map_struct<T, U>(self, mut map: T) -> Data<V, U>
-        where T: FnMut(Fields<F>) -> Fields<U>
+    where
+        T: FnMut(Fields<F>) -> Fields<U>,
     {
         match self {
             Data::Enum(v) => Data::Enum(v),
@@ -101,10 +108,14 @@ impl<V: FromVariant, F: FromField> Data<V, F> {
             syn::Data::Enum(ref data) => {
                 let mut items = Vec::with_capacity(data.variants.len());
                 let mut errors = Vec::new();
-                for v_result in data.variants.clone().into_iter().map(|v| FromVariant::from_variant(&v)) {
+                for v_result in data.variants
+                    .clone()
+                    .into_iter()
+                    .map(|v| FromVariant::from_variant(&v))
+                {
                     match v_result {
                         Ok(val) => items.push(val),
-                        Err(err) => errors.push(err)
+                        Err(err) => errors.push(err),
                     }
                 }
 
@@ -126,7 +137,7 @@ pub struct Fields<T> {
     pub fields: Vec<T>,
 }
 
-#[deprecated(since="0.3", note="this has been renamed to Fields")]
+#[deprecated(since = "0.3", note = "this has been renamed to Fields")]
 pub type VariantData<T> = Fields<T>;
 
 impl<T> Fields<T> {
@@ -167,10 +178,13 @@ impl<T> Fields<T> {
         }
     }
 
-    pub fn map<F, U>(self, map: F) -> Fields<U> where F: FnMut(T) -> U {
+    pub fn map<F, U>(self, map: F) -> Fields<U>
+    where
+        F: FnMut(T) -> U,
+    {
         Fields {
             style: self.style,
-            fields: self.fields.into_iter().map(map).collect()
+            fields: self.fields.into_iter().map(map).collect(),
         }
     }
 }
@@ -190,7 +204,7 @@ impl<F: FromField> Fields<F> {
                             err.at(ident.as_ref())
                         } else {
                             err
-                        })
+                        }),
                     }
                 }
 
@@ -208,7 +222,7 @@ impl<F: FromField> Fields<F> {
                             err.at(ident.as_ref())
                         } else {
                             err
-                        })
+                        }),
                     }
                 }
 
@@ -216,7 +230,6 @@ impl<F: FromField> Fields<F> {
             }
             syn::Fields::Unit => (vec![], vec![]),
         };
-
 
         if !errors.is_empty() {
             Err(Error::multiple(errors))
@@ -286,19 +299,5 @@ impl<'a> From<&'a syn::Fields> for Style {
             syn::Fields::Unnamed(_) => Style::Tuple,
             syn::Fields::Unit => Style::Unit,
         }
-    }
-}
-
-pub struct Generics<P, W = syn::WhereClause> {
-    pub params: Vec<P>,
-    pub where_clause: Option<W>,
-}
-
-impl<P: FromTypeParam> Generics<P, syn::WhereClause> {
-    pub fn try_from(generics: &syn::Generics) -> Result<Self> {
-        Ok(Generics {
-            params: generics.type_params().map(FromTypeParam::from_type_param).collect::<Result<Vec<P>>>()?,
-            where_clause: generics.where_clause.clone(),
-        })
     }
 }

--- a/core/src/codegen/from_derive_impl.rs
+++ b/core/src/codegen/from_derive_impl.rs
@@ -40,7 +40,7 @@ impl<'a> ToTokens for FromDeriveInputImpl<'a> {
 
         let passed_ident = self.ident.as_ref().map(|i| quote!(#i: #input.ident.clone(),));
         let passed_vis = self.vis.as_ref().map(|i| quote!(#i: #input.vis.clone(),));
-        let passed_generics = self.generics.as_ref().map(|i| quote!(#i: #input.generics.clone(),));
+        let passed_generics = self.generics.as_ref().map(|i| quote!(#i: ::darling::FromGenerics::from_generics(&#input.generics)?,));
         let passed_attrs = self.attrs.as_ref().map(|i| quote!(#i: __fwd_attrs,));
         let passed_body = self.data.as_ref().map(|i| quote!(#i: ::darling::ast::Data::try_from(&#input.data)?,));
 

--- a/core/src/codegen/from_type_param.rs
+++ b/core/src/codegen/from_type_param.rs
@@ -8,6 +8,8 @@ pub struct FromTypeParamImpl<'a> {
     pub base: TraitImpl<'a>,
     pub ident: Option<&'a Ident>,
     pub attrs: Option<&'a Ident>,
+    pub bounds: Option<&'a Ident>,
+    pub default: Option<&'a Ident>,
     pub attr_names: Vec<&'a str>,
     pub forward_attrs: Option<&'a ForwardAttrs>,
     pub from_ident: bool,
@@ -30,6 +32,8 @@ impl<'a> ToTokens for FromTypeParamImpl<'a> {
 
         let passed_ident = self.ident.as_ref().map(|i| quote!(#i: #input.ident.clone(),));
         let passed_attrs = self.attrs.as_ref().map(|i| quote!(#i: __fwd_attrs,));
+        let passed_bounds = self.bounds.as_ref().map(|i| quote!(#i: #input.bounds.clone().into_iter().collect::<Vec<_>>(),));
+        let passed_default = self.default.as_ref().map(|i| quote!(#i: #input.default.clone(),));
         let initializers = self.base.initializers();
 
         let map = self.base.map_fn();
@@ -48,6 +52,8 @@ impl<'a> ToTokens for FromTypeParamImpl<'a> {
 
                 ::darling::export::Ok(Self {
                     #passed_ident
+                    #passed_bounds
+                    #passed_default
                     #passed_attrs
                     #initializers
                 }) #map

--- a/core/src/from_generic_param.rs
+++ b/core/src/from_generic_param.rs
@@ -1,0 +1,21 @@
+use syn;
+
+use Result;
+
+/// Creates an instance by parsing a specific `syn::GenericParam`.
+/// This can be a type param, a lifetime, or a const param.
+pub trait FromGenericParam: Sized {
+    fn from_generic_param(param: &syn::GenericParam) -> Result<Self>;
+}
+
+impl FromGenericParam for () {
+    fn from_generic_param(_param: &syn::GenericParam) -> Result<Self> {
+        Ok(())
+    }
+}
+
+impl FromGenericParam for syn::GenericParam {
+    fn from_generic_param(param: &syn::GenericParam) -> Result<Self> {
+        Ok(param.clone())
+    }
+}

--- a/core/src/from_generics.rs
+++ b/core/src/from_generics.rs
@@ -1,0 +1,30 @@
+use syn::Generics;
+
+use {FromTypeParam, Result};
+
+/// Creates an instance by parsing an entire generics declaration, including the
+/// `where` clause.
+pub trait FromGenerics: Sized {
+    fn from_generics(generics: &Generics) -> Result<Self>;
+}
+
+impl FromGenerics for () {
+    fn from_generics(_generics: &Generics) -> Result<Self> {
+        Ok(())
+    }
+}
+
+impl FromGenerics for Generics {
+    fn from_generics(generics: &Generics) -> Result<Self> {
+        Ok(generics.clone())
+    }
+}
+
+impl<T: FromTypeParam> FromGenerics for Vec<T> {
+    fn from_generics(generics: &Generics) -> Result<Self> {
+        generics
+            .type_params()
+            .map(FromTypeParam::from_type_param)
+            .collect()
+    }
+}

--- a/core/src/from_generics.rs
+++ b/core/src/from_generics.rs
@@ -1,6 +1,6 @@
 use syn::Generics;
 
-use {FromTypeParam, Result};
+use Result;
 
 /// Creates an instance by parsing an entire generics declaration, including the
 /// `where` clause.
@@ -20,11 +20,8 @@ impl FromGenerics for Generics {
     }
 }
 
-impl<T: FromTypeParam> FromGenerics for Vec<T> {
+impl<T: FromGenerics> FromGenerics for Result<T> {
     fn from_generics(generics: &Generics) -> Result<Self> {
-        generics
-            .type_params()
-            .map(FromTypeParam::from_type_param)
-            .collect()
+        Ok(FromGenerics::from_generics(generics))
     }
 }

--- a/core/src/from_type_param.rs
+++ b/core/src/from_type_param.rs
@@ -24,3 +24,9 @@ impl FromTypeParam for Vec<syn::Attribute> {
         Ok(type_param.attrs.clone())
     }
 }
+
+impl FromTypeParam for syn::Ident {
+    fn from_type_param(type_param: &TypeParam) -> Result<Self> {
+        Ok(type_param.ident.clone())
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -18,6 +18,7 @@ pub mod error;
 mod from_field;
 mod from_derive_input;
 mod from_generics;
+mod from_generic_param;
 mod from_meta_item;
 mod from_type_param;
 mod from_variant;
@@ -27,12 +28,8 @@ pub mod util;
 pub use error::{Result, Error};
 pub use from_derive_input::FromDeriveInput;
 pub use from_field::FromField;
+pub use from_generic_param::FromGenericParam;
 pub use from_generics::FromGenerics;
 pub use from_meta_item::{FromMetaItem};
 pub use from_type_param::FromTypeParam;
 pub use from_variant::FromVariant;
-
-#[cfg(test)]
-mod tests {
-
-}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -17,6 +17,7 @@ pub mod codegen;
 pub mod error;
 mod from_field;
 mod from_derive_input;
+mod from_generics;
 mod from_meta_item;
 mod from_type_param;
 mod from_variant;
@@ -26,11 +27,12 @@ pub mod util;
 pub use error::{Result, Error};
 pub use from_derive_input::FromDeriveInput;
 pub use from_field::FromField;
+pub use from_generics::FromGenerics;
 pub use from_meta_item::{FromMetaItem};
 pub use from_type_param::FromTypeParam;
 pub use from_variant::FromVariant;
 
 #[cfg(test)]
 mod tests {
-    
+
 }

--- a/core/src/options/from_type_param.rs
+++ b/core/src/options/from_type_param.rs
@@ -1,4 +1,4 @@
-use syn;
+use syn::{self, Ident};
 
 use {Result};
 use codegen::FromTypeParamImpl;
@@ -7,12 +7,16 @@ use options::{ParseAttribute, ParseData, OuterFrom};
 #[derive(Debug)]
 pub struct FromTypeParamOptions {
     pub base: OuterFrom,
+    pub bounds: Option<Ident>,
+    pub default: Option<Ident>,
 }
 
 impl FromTypeParamOptions {
     pub fn new(di: &syn::DeriveInput) -> Result<Self> {
         (FromTypeParamOptions {
             base: OuterFrom::start(di),
+            bounds: None,
+            default: None,
         }).parse_attributes(&di.attrs)?.parse_body(&di.data)
     }
 }
@@ -29,7 +33,11 @@ impl ParseData for FromTypeParamOptions {
     }
 
     fn parse_field(&mut self, field: &syn::Field) -> Result<()> {
-        self.base.parse_field(field)
+        match field.ident.as_ref().map(|v| v.as_ref()) {
+            Some("bounds") => { self.bounds = field.ident.clone(); Ok(()) },
+            Some("default") => { self.default = field.ident.clone(); Ok(()) },
+            _ => self.base.parse_field(field)
+        }
     }
 }
 
@@ -39,6 +47,8 @@ impl<'a> From<&'a FromTypeParamOptions> for FromTypeParamImpl<'a> {
             base: (&v.base.container).into(),
             ident: v.base.ident.as_ref(),
             attrs: v.base.attrs.as_ref(),
+            bounds: v.bounds.as_ref(),
+            default: v.default.as_ref(),
             attr_names: v.base.attr_names.as_strs(),
             forward_attrs: v.base.forward_attrs.as_ref(),
             from_ident: v.base.from_ident,

--- a/core/src/util/ignored.rs
+++ b/core/src/util/ignored.rs
@@ -1,38 +1,29 @@
 use syn;
 
-use {FromMetaItem, FromDeriveInput, FromField, FromVariant, Result};
+use {FromDeriveInput, FromField, FromGenericParam, FromGenerics, FromMetaItem, FromTypeParam,
+     FromVariant, Result};
 
-/// An efficient way of discarding data from an attribute.
+/// An efficient way of discarding data from a syntax element.
 ///
-/// All meta-items, fields, and variants will be successfully read into
+/// All syntax elements will be successfully read into
 /// the `Ignored` struct, with all properties discarded.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub struct Ignored;
 
-impl FromMetaItem for Ignored {
-    fn from_meta_item(_: &syn::Meta) -> Result<Self> {
-        Ok(Ignored)
-    }
-
-    fn from_nested_meta_item(_: &syn::NestedMeta) -> Result<Self> {
-        Ok(Ignored)
-    }
+macro_rules! ignored {
+    ($trayt:ident, $method:ident, $syn:path) => {
+        impl $trayt for Ignored {
+            fn $method(_: &$syn) -> Result<Self> {
+                Ok(Ignored)
+            }
+        }
+    };
 }
 
-impl FromDeriveInput for Ignored {
-    fn from_derive_input(_: &syn::DeriveInput) -> Result<Self> {
-        Ok(Ignored)
-    }
-}
-
-impl FromField for Ignored {
-    fn from_field(_: &syn::Field) -> Result<Self> {
-        Ok(Ignored)
-    }
-}
-
-impl FromVariant for Ignored {
-    fn from_variant(_: &syn::Variant) -> Result<Self> {
-        Ok(Ignored)
-    }
-}
+ignored!(FromGenericParam, from_generic_param, syn::GenericParam);
+ignored!(FromGenerics, from_generics, syn::Generics);
+ignored!(FromTypeParam, from_type_param, syn::TypeParam);
+ignored!(FromMetaItem, from_meta_item, syn::Meta);
+ignored!(FromDeriveInput, from_derive_input, syn::DeriveInput);
+ignored!(FromField, from_field, syn::Field);
+ignored!(FromVariant, from_variant, syn::Variant);

--- a/core/src/util/mod.rs
+++ b/core/src/util/mod.rs
@@ -8,10 +8,12 @@ use {FromMetaItem, Result};
 mod ident_list;
 mod ignored;
 mod over_ride;
+mod with_original;
 
 pub use self::ident_list::IdentList;
 pub use self::ignored::Ignored;
 pub use self::over_ride::Override;
+pub use self::with_original::WithOriginal;
 
 /// Marker type equivalent to `Option<()>` for use in attribute parsing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]

--- a/core/src/util/with_original.rs
+++ b/core/src/util/with_original.rs
@@ -4,7 +4,7 @@ use {FromDeriveInput, FromField, FromGenericParam, FromGenerics, FromMetaItem, F
      FromVariant, Result};
 
 /// A container to parse some syntax and retain access to the original.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WithOriginal<T, O> {
     pub parsed: T,
     pub original: O,

--- a/core/src/util/with_original.rs
+++ b/core/src/util/with_original.rs
@@ -1,0 +1,35 @@
+use syn;
+
+use {FromDeriveInput, FromField, FromGenericParam, FromGenerics, FromMetaItem, FromTypeParam,
+     FromVariant, Result};
+
+/// A container to parse some syntax and retain access to the original.
+#[derive(Debug, Clone)]
+pub struct WithOriginal<T, O> {
+    pub parsed: T,
+    pub original: O,
+}
+
+impl<T, O> WithOriginal<T, O> {
+    pub fn new(parsed: T, original: O) -> Self {
+        WithOriginal { parsed, original }
+    }
+}
+
+macro_rules! with_original {
+    ($trayt:ident, $func:ident, $syn:path) => {
+        impl<T: $trayt> $trayt for WithOriginal<T, $syn> {
+            fn $func(value: &$syn) -> Result<Self> {
+                Ok(WithOriginal::new($trayt::$func(value)?, value.clone()))
+            }
+        }
+    };
+}
+
+with_original!(FromDeriveInput, from_derive_input, syn::DeriveInput);
+with_original!(FromField, from_field, syn::Field);
+with_original!(FromGenerics, from_generics, syn::Generics);
+with_original!(FromGenericParam, from_generic_param, syn::GenericParam);
+with_original!(FromMetaItem, from_meta_item, syn::Meta);
+with_original!(FromTypeParam, from_type_param, syn::TypeParam);
+with_original!(FromVariant, from_variant, syn::Variant);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! ## Design
 //! Darling takes considerable design inspiration from [`serde`]. A data structure that can be
-//! read from any attribute implements `FromMetaItem` (or has an implementation automatically 
+//! read from any attribute implements `FromMetaItem` (or has an implementation automatically
 //! generated using `derive`). Any crate can provide `FromMetaItem` implementations, even one not
 //! specifically geared towards proc-macro authors.
 //!
@@ -24,7 +24,7 @@
 //!   `Default::default()` for their value, but you can override that with an explicit default or a value from the type-level default.
 //!
 //! ## Forwarded Fields
-//! The traits `FromDeriveInput` and `FromField` support forwarding fields from the input AST directly 
+//! The traits `FromDeriveInput` and `FromField` support forwarding fields from the input AST directly
 //! to the derived struct. These fields are matched up by identifier **before** `rename` attribute values are
 //! considered. The deriving struct is responsible for making sure the types of fields it does declare match this
 //! table.
@@ -59,7 +59,7 @@ extern crate darling_macro;
 pub use darling_macro::*;
 
 #[doc(inline)]
-pub use darling_core::{FromMetaItem, FromDeriveInput, FromField, FromTypeParam, FromVariant};
+pub use darling_core::{FromMetaItem, FromDeriveInput, FromGenerics, FromField, FromTypeParam, FromVariant};
 
 #[doc(inline)]
 pub use darling_core::{Result, Error};
@@ -71,7 +71,7 @@ pub use darling_core::{ast, error, util};
 /// depend on `std` unnecessarily, and avoids problems caused by aliasing `std` or any
 /// of the referenced types.
 #[doc(hidden)]
-pub mod export {    
+pub mod export {
     pub use ::core::convert::From;
     pub use ::core::option::Option::{self, Some, None};
     pub use ::core::result::Result::{self, Ok, Err};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,8 @@
 //! generated using `derive`). Any crate can provide `FromMetaItem` implementations, even one not
 //! specifically geared towards proc-macro authors.
 //!
-//! Proc-macro crates should provide their own structs which implement or derive `FromDeriveInput` and
-//! `FromField` to gather settings relevant to their operation.
+//! Proc-macro crates should provide their own structs which implement or derive `FromDeriveInput`,
+//! `FromField`, `FromVariant`, `FromGenerics`, _et alia_ to gather settings relevant to their operation.
 //!
 //! ## Attributes
 //! There are a number of attributes that `darling` exposes to enable finer-grained control over the code
@@ -24,10 +24,10 @@
 //!   `Default::default()` for their value, but you can override that with an explicit default or a value from the type-level default.
 //!
 //! ## Forwarded Fields
-//! The traits `FromDeriveInput` and `FromField` support forwarding fields from the input AST directly
-//! to the derived struct. These fields are matched up by identifier **before** `rename` attribute values are
-//! considered. The deriving struct is responsible for making sure the types of fields it does declare match this
-//! table.
+//! All derivable traits except `FromMetaItem` support forwarding some fields from the input AST to the derived struct.
+//! These fields are matched up by identifier **before** `rename` attribute values are considered,
+//! allowing you to use their names for your own properties.
+//! The deriving struct is responsible for making sure the types of fields it chooses to declare are compatible with this table.
 //!
 //! A deriving struct is free to include or exclude any of the fields below.
 //!
@@ -36,7 +36,7 @@
 //! |---|---|---|
 //! |`ident`|`syn::Ident`|The identifier of the passed-in type|
 //! |`vis`|`syn::Visibility`|The visibility of the passed-in type|
-//! |`generics`|`syn::Generics`|The generics of the passed-in type|
+//! |`generics`|`T: darling::FromGenerics`|The generics of the passed-in type. This can be `syn::Generics`, `darling::ast::Generics`, or any compatible type.|
 //! |`body`|`darling::ast::Data`|The body of the passed-in type|
 //! |`attrs`|`Vec<syn::Attribute>`|The forwarded attributes from the passed in type. These are controlled using the `forward_attrs` attribute.|
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,14 @@
 //! |`vis`|`syn::Visibility`|The visibility of the passed-in field|
 //! |`ty`|`syn::Type`|The type of the passed-in field|
 //! |`attrs`|`Vec<syn::Attribute>`|The forwarded attributes from the passed in field. These are controlled using the `forward_attrs` attribute.|
+//!
+//! ### `FromTypeParam`
+//! |Field name|Type|Meaning|
+//! |---|---|---|
+//! |`ident`|`syn::Ident`|The identifier of the passed-in type param|
+//! |`bounds`|`Vec<syn::TypeParamBound>`|The bounds applied to the type param|
+//! |`default`|`Option<syn::Type>`|The default type of the parameter, if one exists|
+//! |`attrs`|`Vec<syn::Attribute>`|The forwarded attributes from the passed in type param. These are controlled using the `forward_attrs` attribute.|
 
 extern crate core;
 extern crate darling_core;
@@ -59,7 +67,7 @@ extern crate darling_macro;
 pub use darling_macro::*;
 
 #[doc(inline)]
-pub use darling_core::{FromMetaItem, FromDeriveInput, FromGenerics, FromField, FromTypeParam, FromVariant};
+pub use darling_core::{FromMetaItem, FromDeriveInput,  FromGenericParam, FromGenerics, FromField, FromTypeParam, FromVariant};
 
 #[doc(inline)]
 pub use darling_core::{Result, Error};

--- a/tests/from_generics.rs
+++ b/tests/from_generics.rs
@@ -1,0 +1,187 @@
+//! Tests for `FromGenerics`, and - indirectly - `FromGenericParam`.
+//! These tests assume `FromTypeParam` is working and only look at whether the wrappers for magic
+//! fields are working as expected.
+
+#[macro_use]
+extern crate darling;
+extern crate syn;
+
+use darling::ast::{self, GenericParamExt};
+use darling::util::{Ignored, WithOriginal};
+use darling::{FromDeriveInput, Result};
+
+#[derive(FromDeriveInput)]
+#[darling(attributes(lorem))]
+struct MyReceiver {
+    pub ident: syn::Ident,
+    pub generics: ast::Generics<ast::GenericParam<MyTypeParam>>,
+}
+
+#[derive(FromTypeParam)]
+#[darling(attributes(lorem))]
+struct MyTypeParam {
+    pub ident: syn::Ident,
+    #[darling(default)]
+    pub foo: bool,
+    #[darling(default)]
+    pub bar: Option<String>,
+}
+
+fn fdi<T: FromDeriveInput>(src: &str) -> Result<T> {
+    FromDeriveInput::from_derive_input(&syn::parse_str(src).expect("Source parses"))
+}
+
+/// Verify that `ast::Generics` is populated correctly when there is no generics declaration
+#[test]
+fn no_generics() {
+    let rec: MyReceiver = fdi("struct Baz;").expect("Input is well-formed");
+    assert!(rec.generics.where_clause.is_none());
+    assert_eq!(rec.generics.params.len(), 0);
+}
+
+#[test]
+fn expand_some() {
+    let rec: MyReceiver = fdi(r#"
+        struct Baz<
+            'a,
+            #[lorem(foo)] T,
+            #[lorem(bar = "x")] U: Eq + ?Sized
+        >(&'a T, U);
+    "#)
+        .expect("Input is well-formed");
+    assert!(rec.generics.where_clause.is_none());
+
+    // Make sure we've preserved the lifetime def, though we don't do anything with it.
+    assert!(rec.generics.params[0].as_lifetime_def().is_some());
+
+    let mut ty_param_iter = rec.generics.type_params();
+
+    let first = ty_param_iter
+        .next()
+        .expect("type_params should not be empty");
+    assert!(first.bar.is_none());
+    assert!(first.foo);
+    assert_eq!(first.ident.as_ref(), "T");
+
+    let second = ty_param_iter
+        .next()
+        .expect("type_params should have a second value");
+    assert_eq!(
+        second
+            .bar
+            .as_ref()
+            .expect("Second type param should set bar"),
+        "x"
+    );
+    assert_eq!(second.foo, false);
+    assert_eq!(second.ident.as_ref(), "U");
+}
+
+/// Verify ≤0.4.1 behavior - where `generics` had to be `syn::Generics` - keeps working.
+#[test]
+fn passthrough() {
+    #[derive(FromDeriveInput)]
+    struct PassthroughReceiver {
+        pub generics: syn::Generics,
+    }
+
+    let rec: PassthroughReceiver = fdi(r#"
+        struct Baz<
+            'a,
+            #[lorem(foo)] T,
+            #[lorem(bar = "x")] U: Eq + ?Sized
+        >(&'a T, U);
+    "#)
+        .expect("Input is well-formed");
+
+    let mut type_param_iter = rec.generics.type_params();
+    assert!(type_param_iter.next().is_some());
+}
+
+/// Verify that `where_clause` is passed through when it exists.
+/// As of 0.4.1, there is no `FromWhereClause` trait, so other types aren't supported
+/// for that field.
+#[test]
+fn where_clause() {
+    let rec: MyReceiver = fdi(r#"
+        struct Baz<
+            'a,
+            #[lorem(foo)] T,
+            #[lorem(bar = "x")] U: Eq + ?Sized
+        >(&'a T, U) where T: Into<String>;
+    "#)
+        .expect("Input is well-formed");
+
+    assert!(rec.generics.where_clause.is_some());
+}
+
+/// Test that `WithOriginal` works for generics.
+#[test]
+fn with_original() {
+    #[derive(FromDeriveInput)]
+    struct WorigReceiver {
+        generics: WithOriginal<ast::Generics<ast::GenericParam<MyTypeParam>>, syn::Generics>,
+    }
+
+    let rec: WorigReceiver = fdi(r#"
+        struct Baz<
+            'a,
+            #[lorem(foo)] T,
+            #[lorem(bar = "x")] U: Eq + ?Sized
+        >(&'a T, U) where T: Into<String>;
+    "#)
+        .expect("Input is well-formed");
+
+    // Make sure we haven't lost anything in the conversion
+    assert_eq!(rec.generics.parsed.params.len(), 3);
+    assert_eq!(
+        rec.generics
+            .original
+            .params
+            .iter()
+            .collect::<Vec<_>>()
+            .len(),
+        3
+    );
+
+    let parsed_t: &MyTypeParam = rec.generics.parsed.params[1]
+        .as_type_param()
+        .expect("Second argument should be type param");
+
+    // Make sure the first type param in each case is T
+    assert_eq!(parsed_t.ident.as_ref(), "T");
+    assert_eq!(
+        rec.generics
+            .original
+            .type_params()
+            .next()
+            .expect("First type param should exist")
+            .ident
+            .as_ref(),
+        "T"
+    );
+
+    // Make sure we actually parsed the first type param
+    assert!(parsed_t.foo);
+    assert!(parsed_t.bar.is_none());
+}
+
+/// Make sure generics can be ignored
+#[test]
+fn ignored() {
+    #[derive(FromDeriveInput)]
+    struct IgnoredReceiver {
+        generics: Ignored,
+    }
+
+    let rec: IgnoredReceiver = fdi(r#"
+        struct Baz<
+            'a,
+            #[lorem(foo)] T,
+            #[lorem(bar = "x")] U: Eq + ?Sized
+        >(&'a T, U) where T: Into<String>;
+    "#)
+        .expect("Input is well-formed");
+
+    assert_eq!(Ignored, rec.generics);
+}

--- a/tests/from_type_param.rs
+++ b/tests/from_type_param.rs
@@ -9,6 +9,7 @@ use syn::{DeriveInput, GenericParam, Ident, TypeParam};
 #[derive(FromTypeParam)]
 struct Lorem {
     ident: Ident,
+    bounds: Vec<syn::TypeParamBound>,
     foo: bool,
     bar: Option<String>,
 }
@@ -19,6 +20,7 @@ impl From<Ident> for Lorem {
             ident,
             foo: false,
             bar: None,
+            bounds: Default::default(),
         }
     }
 }
@@ -54,5 +56,6 @@ fn expand_many() {
         assert_eq!(lorem.ident.as_ref(), "U");
         assert_eq!(lorem.foo, false);
         assert_eq!(lorem.bar, Some("x".to_string()));
+        assert_eq!(lorem.bounds.len(), 2);
     }
 }

--- a/tests/from_type_param_default.rs
+++ b/tests/from_type_param_default.rs
@@ -10,6 +10,7 @@ use syn::{DeriveInput, GenericParam, TypeParam};
 struct Lorem {
     foo: bool,
     bar: Option<String>,
+    default: Option<syn::Type>,
 }
 
 fn extract_type(param: &GenericParam) -> &TypeParam {
@@ -42,12 +43,14 @@ fn expand_many() {
         let lorem = Lorem::from_type_param(ty).unwrap();
         assert_eq!(lorem.foo, false);
         assert_eq!(lorem.bar, Some("x".to_string()));
+        assert!(lorem.default.is_none());
     }
-    
+
     {
         let ty = extract_type(&params[2]);
         let lorem = Lorem::from_type_param(ty).unwrap();
         assert_eq!(lorem.foo, false);
         assert_eq!(lorem.bar, None);
+        assert!(lorem.default.is_some());
     }
 }


### PR DESCRIPTION
So #31 has proven to be more involved than I anticipated, but I think all this gets it back to a usable state. A caller would now add `generics` in their struct that implements `FromDeriveInput` and would use `darling::ast::Generics` or `darling::util::WithOriginal` to extract the information they want from the generics while preserving the information they want.

- [ ] Update examples to illustrate use of new features
- [x] Write proper tests (it's been a while since I've had to write new tests for `darling` so I need to see how I set it up)

@upsuper if you have a chance to glance over this, that'd be much appreciated; I'm worried I'm going to do something like the blanket impl that will break things down the line.