### PR TITLE
[WIP] Update dependencies to syn 0.14 and proc-macro2 0.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ Cargo.lock
 .vscode
 .rls.toml
 .DS_STORE
+[._]*.sw?
+[._]sw?

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
+sudo: false
 language: rust
-env:
+
+rust:
+  - 1.18.0
   - stable
   - beta
   - nightly
+
+env:
+  global:
+    - RUST_BACKTRACE=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Add `util::IdentString`, which acts as an Ident or its string equivalent
+
 ## v0.6.3 (May 22, 2018)
 - Add support for `Uses*` traits in where predicates
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ darling_core = { version = "=0.6.3", path = "core" }
 darling_macro = { version = "=0.6.3", path = "macro" }
 
 [dev-dependencies]
+proc-macro2 = "0.4"
 quote = "0.6"
 syn = "0.14"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ darling_core = { version = "=0.6.3", path = "core" }
 darling_macro = { version = "=0.6.3", path = "macro" }
 
 [dev-dependencies]
-quote = "0.5"
-syn = "0.13"
+quote = "0.6"
+syn = "0.14"
 
 [workspace]
 members = ["macro", "core"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -16,7 +16,7 @@ default = ["syn/full"]
 
 [dependencies]
 ident_case = "1.0.0"
-proc-macro2 = "0.3"
-quote = "0.5"
-syn = { version = "0.13", features = ["extra-traits"] }
+proc-macro2 = "0.4.2"
+quote = "0.6"
+syn = { version = "0.14", features = ["extra-traits"] }
 fnv = "1.0.6"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,13 +10,15 @@ implementing custom derives. Use https://crates.io/crates/darling in your code.
 license = "MIT"
 
 [features]
-# temporary hack to make Racer autocomplete work; it requires a 3-part version
-# number and doesn't allow for any feature declarations.
-default = ["syn/full"]
+# Note about "syn/full": this is a temporary hack to make Racer autocomplete
+# work; it requires a 3-part version number and doesn't allow for any feature
+# declarations.
+default = ["proc-macro", "syn/full"]
+proc-macro = ["proc-macro2/proc-macro", "quote/proc-macro", "syn/proc-macro"]
 
 [dependencies]
 ident_case = "1.0.0"
-proc-macro2 = "0.4.2"
-quote = "0.6"
-syn = { version = "0.14", features = ["extra-traits"] }
+proc-macro2 = { version = "0.4.2", default-features = false }
+quote = { version = "0.6", default-features = false }
+syn = { version = "0.14", default-features = false, features = ["derive", "parsing", "printing", "clone-impls", "extra-traits"] }
 fnv = "1.0.6"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,15 +10,13 @@ implementing custom derives. Use https://crates.io/crates/darling in your code.
 license = "MIT"
 
 [features]
-# Note about "syn/full": this is a temporary hack to make Racer autocomplete
-# work; it requires a 3-part version number and doesn't allow for any feature
-# declarations.
-default = ["proc-macro", "syn/full"]
-proc-macro = ["proc-macro2/proc-macro", "quote/proc-macro", "syn/proc-macro"]
+# temporary hack to make Racer autocomplete work; it requires a 3-part version
+# number and doesn't allow for any feature declarations.
+default = ["syn/full"]
 
 [dependencies]
 ident_case = "1.0.0"
-proc-macro2 = { version = "0.4.2", default-features = false }
-quote = { version = "0.6", default-features = false }
-syn = { version = "0.14", default-features = false, features = ["derive", "parsing", "printing", "clone-impls", "extra-traits"] }
+proc-macro2 = "0.4.2"
+quote = "0.6"
+syn = { version = "0.14", features = ["extra-traits"] }
 fnv = "1.0.6"

--- a/core/src/ast/data.rs
+++ b/core/src/ast/data.rs
@@ -230,7 +230,7 @@ impl<F: FromField> Fields<F> {
                     match f_result {
                         Ok(val) => items.push(val),
                         Err(err) => errors.push(if let Some(ref ident) = field.ident {
-                            err.at(ident.as_ref())
+                            err.at(ident)
                         } else {
                             err
                         }),
@@ -248,7 +248,7 @@ impl<F: FromField> Fields<F> {
                     match f_result {
                         Ok(val) => items.push(val),
                         Err(err) => errors.push(if let Some(ref ident) = field.ident {
-                            err.at(ident.as_ref())
+                            err.at(ident)
                         } else {
                             err
                         }),

--- a/core/src/codegen/attr_extractor.rs
+++ b/core/src/codegen/attr_extractor.rs
@@ -1,0 +1,109 @@
+use proc_macro2::TokenStream;
+
+use options::ForwardAttrs;
+use util::IdentList;
+
+/// Infrastructure for generating an attribute extractor.
+pub trait ExtractAttribute {
+    /// A set of mutable declarations for all members of the implementing type.
+    fn local_declarations(&self) -> TokenStream;
+
+    /// A set of immutable declarations for all members of the implementing type.
+    /// This is used in the case where a deriving struct handles no attributes and therefore can
+    /// never change its default state.
+    fn immutable_declarations(&self) -> TokenStream;
+
+    /// Gets the list of attribute names that should be parsed by the extractor.
+    fn attr_names(&self) -> &IdentList;
+
+    fn forwarded_attrs(&self) -> Option<&ForwardAttrs>;
+
+    /// Gets the name used by the generated impl to return to the `syn` item passed as input.
+    fn param_name(&self) -> TokenStream;
+
+    /// Gets the core from-meta-item loop that should be used on matching attributes.
+    fn core_loop(&self) -> TokenStream;
+
+    fn declarations(&self) -> TokenStream {
+        if !self.attr_names().is_empty() {
+            self.local_declarations()
+        } else {
+            self.immutable_declarations()
+        }
+    }
+
+    /// Generates the main extraction loop.
+    fn extractor(&self) -> TokenStream {
+        let declarations = self.declarations();
+
+        let will_parse_any = !self.attr_names().is_empty();
+        let will_fwd_any = self.forwarded_attrs()
+            .map(|fa| !fa.is_empty())
+            .unwrap_or_default();
+
+        if !(will_parse_any || will_fwd_any) {
+            return quote! {
+                #declarations
+            };
+        }
+
+        let input = self.param_name();
+
+        // The block for parsing attributes whose names have been claimed by the target
+        // struct. If no attributes were claimed, this is a pass-through.
+        let parse_handled = if will_parse_any {
+            let attr_names = self.attr_names().to_strings();
+            let core_loop = self.core_loop();
+            quote!(
+                #(#attr_names)|* => {
+                    if let Some(::syn::Meta::List(ref __data)) = __attr.interpret_meta() {
+                        let __items = &__data.nested;
+
+                        #core_loop
+                    } else {
+                        // darling currently only supports list-style
+                        continue
+                    }
+                }
+            )
+        } else {
+            quote!()
+        };
+
+        // Specifies the behavior for unhandled attributes. They will either be silently ignored or
+        // forwarded to the inner struct for later analysis.
+        let forward_unhandled = if will_fwd_any {
+            forwards_to_local(self.forwarded_attrs().unwrap())
+        } else {
+            quote!(_ => continue)
+        };
+
+        quote!(
+            #declarations
+            use ::darling::ToTokens;
+            let mut __fwd_attrs: ::darling::export::Vec<::syn::Attribute> = vec![];
+
+            for __attr in &#input.attrs {
+                // Filter attributes based on name
+                match  ::darling::export::ToString::to_string(&__attr.path.clone().into_token_stream()).as_str() {
+                    #parse_handled
+                    #forward_unhandled
+                }
+            }
+        )
+    }
+}
+
+fn forwards_to_local(behavior: &ForwardAttrs) -> TokenStream {
+    let push_command = quote!(__fwd_attrs.push(__attr.clone()));
+    match *behavior {
+        ForwardAttrs::All => quote!(_ => #push_command),
+        ForwardAttrs::Only(ref idents) => {
+            let names = idents.to_strings();
+            quote!(
+                #(#names)|* => #push_command,
+                _ => continue,
+            )
+        }
+    }
+}

--- a/core/src/codegen/default_expr.rs
+++ b/core/src/codegen/default_expr.rs
@@ -1,4 +1,5 @@
-use quote::{ToTokens, Tokens};
+use proc_macro2::TokenStream;
+use quote::{TokenStreamExt, ToTokens};
 use syn::{Ident, Path};
 
 /// This will be in scope during struct initialization after option parsing.
@@ -21,7 +22,7 @@ impl<'a> DefaultExpression<'a> {
 }
 
 impl<'a> ToTokens for DefaultExpression<'a> {
-    fn to_tokens(&self, tokens: &mut Tokens) {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
         tokens.append_all(match *self {
             DefaultExpression::Inherit(ident) => {
                 let dsn = Ident::new(DEFAULT_STRUCT_NAME, ::proc_macro2::Span::call_site());
@@ -37,7 +38,7 @@ impl<'a> ToTokens for DefaultExpression<'a> {
 pub struct DefaultDeclaration<'a>(&'a DefaultExpression<'a>);
 
 impl<'a> ToTokens for DefaultDeclaration<'a> {
-    fn to_tokens(&self, tokens: &mut Tokens) {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
         let name = Ident::new(DEFAULT_STRUCT_NAME, ::proc_macro2::Span::call_site());
         let expr = self.0;
         tokens.append_all(quote!(let #name: Self = #expr;));

--- a/core/src/codegen/error.rs
+++ b/core/src/codegen/error.rs
@@ -1,4 +1,5 @@
-use quote::{ToTokens, Tokens};
+use proc_macro2::TokenStream;
+use quote::{TokenStreamExt, ToTokens};
 
 /// Declares the local variable into which errors will be accumulated.
 pub struct ErrorDeclaration {
@@ -12,7 +13,7 @@ impl ErrorDeclaration {
 }
 
 impl ToTokens for ErrorDeclaration {
-    fn to_tokens(&self, tokens: &mut Tokens) {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
         tokens.append_all(quote! {
             let mut __errors = Vec::new();
         })
@@ -42,7 +43,7 @@ impl<'a> ErrorCheck<'a> {
 }
 
 impl<'a> ToTokens for ErrorCheck<'a> {
-    fn to_tokens(&self, tokens: &mut Tokens) {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
         let at_call = if let Some(ref s) = self.location {
             quote!(.at(#s))
         } else {

--- a/core/src/codegen/field.rs
+++ b/core/src/codegen/field.rs
@@ -1,4 +1,5 @@
-use quote::{ToTokens, Tokens};
+use proc_macro2::TokenStream;
+use quote::{TokenStreamExt, ToTokens};
 use syn::{Ident, Path, Type};
 
 use codegen::DefaultExpression;
@@ -64,7 +65,7 @@ impl<'a> Declaration<'a> {
 }
 
 impl<'a> ToTokens for Declaration<'a> {
-    fn to_tokens(&self, tokens: &mut Tokens) {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
         let field: &Field = self.0;
         let ident = field.ident;
         let ty = field.ty;
@@ -84,7 +85,7 @@ impl<'a> ToTokens for Declaration<'a> {
 pub struct MatchArm<'a>(&'a Field<'a>);
 
 impl<'a> ToTokens for MatchArm<'a> {
-    fn to_tokens(&self, tokens: &mut Tokens) {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
         let field: &Field = self.0;
         if !field.skip {
             let name_str = field.name_in_attr;
@@ -151,7 +152,7 @@ impl<'a> ToTokens for MatchArm<'a> {
 pub struct Initializer<'a>(&'a Field<'a>);
 
 impl<'a> ToTokens for Initializer<'a> {
-    fn to_tokens(&self, tokens: &mut Tokens) {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
         let field: &Field = self.0;
         let ident = field.ident;
         tokens.append_all(if field.multiple {
@@ -181,7 +182,7 @@ impl<'a> ToTokens for Initializer<'a> {
 pub struct CheckMissing<'a>(&'a Field<'a>);
 
 impl<'a> ToTokens for CheckMissing<'a> {
-    fn to_tokens(&self, tokens: &mut Tokens) {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
         if !self.0.multiple && self.0.default_expression.is_none() {
             let ident = self.0.ident;
             let name_in_attr = self.0.name_in_attr;

--- a/core/src/codegen/field.rs
+++ b/core/src/codegen/field.rs
@@ -11,7 +11,7 @@ use usage::{self, IdentRefSet, IdentSet, UsesTypeParams};
 pub struct Field<'a> {
     /// The name presented to the user of the library. This will appear
     /// in error messages and will be looked when parsing names.
-    pub name_in_attr: &'a str,
+    pub name_in_attr: String,
 
     /// The name presented to the author of the library. This will appear
     /// in the setters or temporary variables which contain the values.
@@ -88,7 +88,7 @@ impl<'a> ToTokens for MatchArm<'a> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let field: &Field = self.0;
         if !field.skip {
-            let name_str = field.name_in_attr;
+            let name_str = &field.name_in_attr;
             let ident = field.ident;
             let with_path = &field.with_path;
 
@@ -185,7 +185,7 @@ impl<'a> ToTokens for CheckMissing<'a> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         if !self.0.multiple && self.0.default_expression.is_none() {
             let ident = self.0.ident;
-            let name_in_attr = self.0.name_in_attr;
+            let name_in_attr = &self.0.name_in_attr;
 
             tokens.append_all(quote! {
                 if !#ident.0 {

--- a/core/src/codegen/from_derive_impl.rs
+++ b/core/src/codegen/from_derive_impl.rs
@@ -1,4 +1,5 @@
-use quote::{ToTokens, Tokens};
+use proc_macro2::TokenStream;
+use quote::ToTokens;
 use syn::{self, Ident};
 
 use ast::Data;
@@ -19,7 +20,7 @@ pub struct FromDeriveInputImpl<'a> {
 }
 
 impl<'a> ToTokens for FromDeriveInputImpl<'a> {
-    fn to_tokens(&self, tokens: &mut Tokens) {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
         let ty_ident = self.base.ident;
         let input = self.param_name();
         let map = self.base.map_fn();
@@ -112,19 +113,19 @@ impl<'a> ExtractAttribute for FromDeriveInputImpl<'a> {
         self.forward_attrs
     }
 
-    fn param_name(&self) -> Tokens {
+    fn param_name(&self) -> TokenStream {
         quote!(__di)
     }
 
-    fn core_loop(&self) -> Tokens {
+    fn core_loop(&self) -> TokenStream {
         self.base.core_loop()
     }
 
-    fn local_declarations(&self) -> Tokens {
+    fn local_declarations(&self) -> TokenStream {
         self.base.local_declarations()
     }
 
-    fn immutable_declarations(&self) -> Tokens {
+    fn immutable_declarations(&self) -> TokenStream {
         self.base.immutable_declarations()
     }
 }

--- a/core/src/codegen/from_derive_impl.rs
+++ b/core/src/codegen/from_derive_impl.rs
@@ -5,6 +5,7 @@ use syn::{self, Ident};
 use ast::Data;
 use codegen::{ExtractAttribute, OuterFromImpl, TraitImpl};
 use options::{ForwardAttrs, Shape};
+use util::IdentList;
 
 pub struct FromDeriveInputImpl<'a> {
     pub ident: Option<&'a Ident>,
@@ -13,7 +14,7 @@ pub struct FromDeriveInputImpl<'a> {
     pub attrs: Option<&'a Ident>,
     pub data: Option<&'a Ident>,
     pub base: TraitImpl<'a>,
-    pub attr_names: Vec<&'a str>,
+    pub attr_names: &'a IdentList,
     pub forward_attrs: Option<&'a ForwardAttrs>,
     pub from_ident: bool,
     pub supports: Option<&'a Shape>,
@@ -105,8 +106,8 @@ impl<'a> ToTokens for FromDeriveInputImpl<'a> {
 }
 
 impl<'a> ExtractAttribute for FromDeriveInputImpl<'a> {
-    fn attr_names(&self) -> &[&str] {
-        self.attr_names.as_slice()
+    fn attr_names(&self) -> &IdentList {
+        &self.attr_names
     }
 
     fn forwarded_attrs(&self) -> Option<&ForwardAttrs> {

--- a/core/src/codegen/from_field.rs
+++ b/core/src/codegen/from_field.rs
@@ -1,4 +1,5 @@
-use quote::{ToTokens, Tokens};
+use proc_macro2::TokenStream;
+use quote::ToTokens;
 use syn::{self, Ident};
 
 use codegen::{ExtractAttribute, OuterFromImpl, TraitImpl};
@@ -18,7 +19,7 @@ pub struct FromFieldImpl<'a> {
 }
 
 impl<'a> ToTokens for FromFieldImpl<'a> {
-    fn to_tokens(&self, tokens: &mut Tokens) {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
         let input = self.param_name();
 
         let error_declaration = self.base.declare_errors();
@@ -81,19 +82,19 @@ impl<'a> ExtractAttribute for FromFieldImpl<'a> {
         self.forward_attrs
     }
 
-    fn param_name(&self) -> Tokens {
+    fn param_name(&self) -> TokenStream {
         quote!(__field)
     }
 
-    fn core_loop(&self) -> Tokens {
+    fn core_loop(&self) -> TokenStream {
         self.base.core_loop()
     }
 
-    fn local_declarations(&self) -> Tokens {
+    fn local_declarations(&self) -> TokenStream {
         self.base.local_declarations()
     }
 
-    fn immutable_declarations(&self) -> Tokens {
+    fn immutable_declarations(&self) -> TokenStream {
         self.base.immutable_declarations()
     }
 }

--- a/core/src/codegen/from_field.rs
+++ b/core/src/codegen/from_field.rs
@@ -4,6 +4,7 @@ use syn::{self, Ident};
 
 use codegen::{ExtractAttribute, OuterFromImpl, TraitImpl};
 use options::ForwardAttrs;
+use util::IdentList;
 
 /// `impl FromField` generator. This is used for parsing an individual
 /// field and its attributes.
@@ -13,7 +14,7 @@ pub struct FromFieldImpl<'a> {
     pub ty: Option<&'a Ident>,
     pub attrs: Option<&'a Ident>,
     pub base: TraitImpl<'a>,
-    pub attr_names: Vec<&'a str>,
+    pub attr_names: &'a IdentList,
     pub forward_attrs: Option<&'a ForwardAttrs>,
     pub from_ident: bool,
 }
@@ -74,8 +75,8 @@ impl<'a> ToTokens for FromFieldImpl<'a> {
 }
 
 impl<'a> ExtractAttribute for FromFieldImpl<'a> {
-    fn attr_names(&self) -> &[&str] {
-        self.attr_names.as_slice()
+    fn attr_names(&self) -> &IdentList {
+        &self.attr_names
     }
 
     fn forwarded_attrs(&self) -> Option<&ForwardAttrs> {

--- a/core/src/codegen/from_meta_impl.rs
+++ b/core/src/codegen/from_meta_impl.rs
@@ -1,4 +1,5 @@
-use quote::{ToTokens, Tokens};
+use proc_macro2::TokenStream;
+use quote::ToTokens;
 use syn;
 
 use ast::{Data, Fields, Style};
@@ -9,7 +10,7 @@ pub struct FromMetaImpl<'a> {
 }
 
 impl<'a> ToTokens for FromMetaImpl<'a> {
-    fn to_tokens(&self, tokens: &mut Tokens) {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
         let base = &self.base;
 
         let impl_block = match base.data {

--- a/core/src/codegen/from_meta_impl.rs
+++ b/core/src/codegen/from_meta_impl.rs
@@ -87,7 +87,7 @@ impl<'a> ToTokens for FromMetaImpl<'a> {
                             0 => ::darling::export::Err(::darling::Error::too_few_items(1)),
                             1 => {
                                 if let ::syn::NestedMeta::Meta(ref __nested) = __outer[0] {
-                                    match __nested.name().as_ref() {
+                                    match __nested.name().to_string().as_ref() {
                                         #(#struct_arms)*
                                         __other => ::darling::export::Err(::darling::Error::unknown_value(__other))
                                     }

--- a/core/src/codegen/from_type_param.rs
+++ b/core/src/codegen/from_type_param.rs
@@ -1,4 +1,5 @@
-use quote::{ToTokens, Tokens};
+use proc_macro2::TokenStream;
+use quote::ToTokens;
 use syn::{self, Ident};
 
 use codegen::{ExtractAttribute, OuterFromImpl, TraitImpl};
@@ -16,7 +17,7 @@ pub struct FromTypeParamImpl<'a> {
 }
 
 impl<'a> ToTokens for FromTypeParamImpl<'a> {
-    fn to_tokens(&self, tokens: &mut Tokens) {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
         let input = self.param_name();
 
         let error_declaration = self.base.declare_errors();
@@ -80,19 +81,19 @@ impl<'a> ExtractAttribute for FromTypeParamImpl<'a> {
         self.forward_attrs
     }
 
-    fn param_name(&self) -> Tokens {
+    fn param_name(&self) -> TokenStream {
         quote!(__type_param)
     }
 
-    fn core_loop(&self) -> Tokens {
+    fn core_loop(&self) -> TokenStream {
         self.base.core_loop()
     }
 
-    fn local_declarations(&self) -> Tokens {
+    fn local_declarations(&self) -> TokenStream {
         self.base.local_declarations()
     }
 
-    fn immutable_declarations(&self) -> Tokens {
+    fn immutable_declarations(&self) -> TokenStream {
         self.base.immutable_declarations()
     }
 }

--- a/core/src/codegen/from_type_param.rs
+++ b/core/src/codegen/from_type_param.rs
@@ -4,6 +4,7 @@ use syn::{self, Ident};
 
 use codegen::{ExtractAttribute, OuterFromImpl, TraitImpl};
 use options::ForwardAttrs;
+use util::IdentList;
 
 pub struct FromTypeParamImpl<'a> {
     pub base: TraitImpl<'a>,
@@ -11,7 +12,7 @@ pub struct FromTypeParamImpl<'a> {
     pub attrs: Option<&'a Ident>,
     pub bounds: Option<&'a Ident>,
     pub default: Option<&'a Ident>,
-    pub attr_names: Vec<&'a str>,
+    pub attr_names: &'a IdentList,
     pub forward_attrs: Option<&'a ForwardAttrs>,
     pub from_ident: bool,
 }
@@ -73,8 +74,8 @@ impl<'a> ToTokens for FromTypeParamImpl<'a> {
 }
 
 impl<'a> ExtractAttribute for FromTypeParamImpl<'a> {
-    fn attr_names(&self) -> &[&str] {
-        self.attr_names.as_slice()
+    fn attr_names(&self) -> &IdentList {
+        &self.attr_names
     }
 
     fn forwarded_attrs(&self) -> Option<&ForwardAttrs> {

--- a/core/src/codegen/from_variant_impl.rs
+++ b/core/src/codegen/from_variant_impl.rs
@@ -1,4 +1,5 @@
-use quote::{ToTokens, Tokens};
+use proc_macro2::TokenStream;
+use quote::ToTokens;
 use syn::{self, Ident};
 
 use codegen::{ExtractAttribute, OuterFromImpl, TraitImpl};
@@ -16,7 +17,7 @@ pub struct FromVariantImpl<'a> {
 }
 
 impl<'a> ToTokens for FromVariantImpl<'a> {
-    fn to_tokens(&self, tokens: &mut Tokens) {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
         let input = self.param_name();
         let extractor = self.extractor();
         let passed_ident = self.ident
@@ -76,11 +77,11 @@ impl<'a> ToTokens for FromVariantImpl<'a> {
 }
 
 impl<'a> ExtractAttribute for FromVariantImpl<'a> {
-    fn local_declarations(&self) -> Tokens {
+    fn local_declarations(&self) -> TokenStream {
         self.base.local_declarations()
     }
 
-    fn immutable_declarations(&self) -> Tokens {
+    fn immutable_declarations(&self) -> TokenStream {
         self.base.immutable_declarations()
     }
 
@@ -92,11 +93,11 @@ impl<'a> ExtractAttribute for FromVariantImpl<'a> {
         self.forward_attrs
     }
 
-    fn param_name(&self) -> Tokens {
+    fn param_name(&self) -> TokenStream {
         quote!(__variant)
     }
 
-    fn core_loop(&self) -> Tokens {
+    fn core_loop(&self) -> TokenStream {
         self.base.core_loop()
     }
 }

--- a/core/src/codegen/from_variant_impl.rs
+++ b/core/src/codegen/from_variant_impl.rs
@@ -4,13 +4,14 @@ use syn::{self, Ident};
 
 use codegen::{ExtractAttribute, OuterFromImpl, TraitImpl};
 use options::{DataShape, ForwardAttrs};
+use util::IdentList;
 
 pub struct FromVariantImpl<'a> {
     pub base: TraitImpl<'a>,
     pub ident: Option<&'a Ident>,
     pub fields: Option<&'a Ident>,
     pub attrs: Option<&'a Ident>,
-    pub attr_names: Vec<&'a str>,
+    pub attr_names: &'a IdentList,
     pub forward_attrs: Option<&'a ForwardAttrs>,
     pub from_ident: bool,
     pub supports: Option<&'a DataShape>,
@@ -85,8 +86,8 @@ impl<'a> ExtractAttribute for FromVariantImpl<'a> {
         self.base.immutable_declarations()
     }
 
-    fn attr_names(&self) -> &[&str] {
-        self.attr_names.as_slice()
+    fn attr_names(&self) -> &IdentList {
+        &self.attr_names
     }
 
     fn forwarded_attrs(&self) -> Option<&ForwardAttrs> {

--- a/core/src/codegen/mod.rs
+++ b/core/src/codegen/mod.rs
@@ -1,5 +1,5 @@
-use proc_macro2::TokenStream;
 
+mod attr_extractor;
 mod default_expr;
 mod error;
 mod field;
@@ -13,6 +13,7 @@ mod trait_impl;
 mod variant;
 mod variant_data;
 
+pub(in codegen) use self::attr_extractor::ExtractAttribute;
 pub use self::default_expr::DefaultExpression;
 pub use self::field::Field;
 pub use self::from_meta_impl::FromMetaImpl;
@@ -25,106 +26,4 @@ pub use self::trait_impl::TraitImpl;
 pub use self::variant::Variant;
 pub use self::variant_data::FieldsGen;
 
-use options::ForwardAttrs;
-use util::IdentList;
 
-/// Infrastructure for generating an attribute extractor.
-pub trait ExtractAttribute {
-    fn local_declarations(&self) -> TokenStream;
-
-    fn immutable_declarations(&self) -> TokenStream;
-
-    /// Gets the list of attribute names that should be parsed by the extractor.
-    fn attr_names(&self) -> &IdentList;
-
-    fn forwarded_attrs(&self) -> Option<&ForwardAttrs>;
-
-    /// Gets the name used by the generated impl to return to the `syn` item passed as input.
-    fn param_name(&self) -> TokenStream;
-
-    /// Gets the core from-meta-item loop that should be used on matching attributes.
-    fn core_loop(&self) -> TokenStream;
-
-    fn declarations(&self) -> TokenStream {
-        if !self.attr_names().is_empty() {
-            self.local_declarations()
-        } else {
-            self.immutable_declarations()
-        }
-    }
-
-    /// Generates the main extraction loop.
-    fn extractor(&self) -> TokenStream {
-        let declarations = self.declarations();
-
-        let will_parse_any = !self.attr_names().is_empty();
-        let will_fwd_any = self.forwarded_attrs()
-            .map(|fa| !fa.is_empty())
-            .unwrap_or_default();
-
-        if !(will_parse_any || will_fwd_any) {
-            return quote! {
-                #declarations
-            };
-        }
-
-        let input = self.param_name();
-
-        // The block for parsing attributes whose names have been claimed by the target
-        // struct. If no attributes were claimed, this is a pass-through.
-        let parse_handled = if will_parse_any {
-            let attr_names = self.attr_names().to_strings();
-            let core_loop = self.core_loop();
-            quote!(
-                #(#attr_names)|* => {
-                    if let Some(::syn::Meta::List(ref __data)) = __attr.interpret_meta() {
-                        let __items = &__data.nested;
-
-                        #core_loop
-                    } else {
-                        // darling currently only supports list-style
-                        continue
-                    }
-                }
-            )
-        } else {
-            quote!()
-        };
-
-        // Specifies the behavior for unhandled attributes. They will either be silently ignored or
-        // forwarded to the inner struct for later analysis.
-        let forward_unhandled = if will_fwd_any {
-            forwards_to_local(self.forwarded_attrs().unwrap())
-        } else {
-            quote!(_ => continue)
-        };
-
-        quote!(
-            #declarations
-            use ::darling::ToTokens;
-            let mut __fwd_attrs: ::darling::export::Vec<::syn::Attribute> = vec![];
-
-            for __attr in &#input.attrs {
-                // Filter attributes based on name
-                match  ::darling::export::ToString::to_string(&__attr.path.clone().into_token_stream()).as_str() {
-                    #parse_handled
-                    #forward_unhandled
-                }
-            }
-        )
-    }
-}
-
-fn forwards_to_local(behavior: &ForwardAttrs) -> TokenStream {
-    let push_command = quote!(__fwd_attrs.push(__attr.clone()));
-    match *behavior {
-        ForwardAttrs::All => quote!(_ => #push_command),
-        ForwardAttrs::Only(ref idents) => {
-            let names = idents.to_strings();
-            quote!(
-                #(#names)|* => #push_command,
-                _ => continue,
-            )
-        }
-    }
-}

--- a/core/src/codegen/mod.rs
+++ b/core/src/codegen/mod.rs
@@ -1,4 +1,4 @@
-use quote::Tokens;
+use proc_macro2::TokenStream;
 
 mod default_expr;
 mod error;
@@ -29,9 +29,9 @@ use options::ForwardAttrs;
 
 /// Infrastructure for generating an attribute extractor.
 pub trait ExtractAttribute {
-    fn local_declarations(&self) -> Tokens;
+    fn local_declarations(&self) -> TokenStream;
 
-    fn immutable_declarations(&self) -> Tokens;
+    fn immutable_declarations(&self) -> TokenStream;
 
     /// Gets the list of attribute names that should be parsed by the extractor.
     fn attr_names(&self) -> &[&str];
@@ -39,12 +39,12 @@ pub trait ExtractAttribute {
     fn forwarded_attrs(&self) -> Option<&ForwardAttrs>;
 
     /// Gets the name used by the generated impl to return to the `syn` item passed as input.
-    fn param_name(&self) -> Tokens;
+    fn param_name(&self) -> TokenStream;
 
     /// Gets the core from-meta-item loop that should be used on matching attributes.
-    fn core_loop(&self) -> Tokens;
+    fn core_loop(&self) -> TokenStream;
 
-    fn declarations(&self) -> Tokens {
+    fn declarations(&self) -> TokenStream {
         if !self.attr_names().is_empty() {
             self.local_declarations()
         } else {
@@ -53,7 +53,7 @@ pub trait ExtractAttribute {
     }
 
     /// Generates the main extraction loop.
-    fn extractor(&self) -> Tokens {
+    fn extractor(&self) -> TokenStream {
         let declarations = self.declarations();
 
         let will_parse_any = !self.attr_names().is_empty();
@@ -113,7 +113,7 @@ pub trait ExtractAttribute {
     }
 }
 
-fn forwards_to_local(behavior: &ForwardAttrs) -> Tokens {
+fn forwards_to_local(behavior: &ForwardAttrs) -> TokenStream {
     let push_command = quote!(__fwd_attrs.push(__attr.clone()));
     match *behavior {
         ForwardAttrs::All => quote!(_ => #push_command),

--- a/core/src/codegen/outer_from_impl.rs
+++ b/core/src/codegen/outer_from_impl.rs
@@ -1,4 +1,5 @@
-use quote::{ToTokens, Tokens};
+use proc_macro2::TokenStream;
+use quote::{TokenStreamExt, ToTokens};
 use syn::{GenericParam, Generics, Path, TraitBound, TraitBoundModifier, TypeParamBound};
 
 use codegen::TraitImpl;
@@ -15,7 +16,7 @@ pub trait OuterFromImpl<'a> {
         self.trait_path()
     }
 
-    fn wrap<T: ToTokens>(&'a self, body: T, tokens: &mut Tokens) {
+    fn wrap<T: ToTokens>(&'a self, body: T, tokens: &mut TokenStream) {
         let base = self.base();
         let trayt = self.trait_path();
         let ty_ident = base.ident;

--- a/core/src/codegen/trait_impl.rs
+++ b/core/src/codegen/trait_impl.rs
@@ -68,15 +68,10 @@ impl<'a> TraitImpl<'a> {
     where
         F: Fn(&&'b Field) -> bool,
     {
-        let mut hits = IdentSet::default();
-        hits.extend(
-            fields
-                .iter()
-                .filter(field_filter)
-                .collect_type_params(&Purpose::BoundImpl.into(), declared),
-        );
-
-        hits
+        fields
+            .iter()
+            .filter(field_filter)
+            .collect_type_params_cloned(&Purpose::BoundImpl.into(), declared)
     }
 }
 

--- a/core/src/codegen/trait_impl.rs
+++ b/core/src/codegen/trait_impl.rs
@@ -1,4 +1,4 @@
-use quote::Tokens;
+use proc_macro2::TokenStream;
 use syn::{Generics, Ident, Path, WherePredicate};
 
 use ast::{Data, Fields};
@@ -92,7 +92,7 @@ impl<'a> TraitImpl<'a> {
     }
 
     /// Generate local variable declarations for all fields.
-    pub(in codegen) fn local_declarations(&self) -> Tokens {
+    pub(in codegen) fn local_declarations(&self) -> TokenStream {
         if let Data::Struct(ref vd) = self.data {
             let vdr = vd.as_ref().map(Field::as_declaration);
             let decls = vdr.fields.as_slice();
@@ -103,7 +103,7 @@ impl<'a> TraitImpl<'a> {
     }
 
     /// Generate immutable variable declarations for all fields.
-    pub(in codegen) fn immutable_declarations(&self) -> Tokens {
+    pub(in codegen) fn immutable_declarations(&self) -> TokenStream {
         if let Data::Struct(ref vd) = self.data {
             let vdr = vd.as_ref().map(|f| field::Declaration::new(f, false));
             let decls = vdr.fields.as_slice();
@@ -113,17 +113,17 @@ impl<'a> TraitImpl<'a> {
         }
     }
 
-    pub(in codegen) fn map_fn(&self) -> Option<Tokens> {
+    pub(in codegen) fn map_fn(&self) -> Option<TokenStream> {
         self.map.as_ref().map(|path| quote!(.map(#path)))
     }
 
     /// Generate local variable declaration and initialization for instance from which missing fields will be taken.
-    pub(in codegen) fn fallback_decl(&self) -> Tokens {
+    pub(in codegen) fn fallback_decl(&self) -> TokenStream {
         let default = self.default.as_ref().map(DefaultExpression::as_declaration);
         quote!(#default)
     }
 
-    pub fn require_fields(&self) -> Tokens {
+    pub fn require_fields(&self) -> TokenStream {
         if let Data::Struct(ref vd) = self.data {
             let check_nones = vd.as_ref().map(Field::as_presence_check);
             let checks = check_nones.fields.as_slice();
@@ -133,7 +133,7 @@ impl<'a> TraitImpl<'a> {
         }
     }
 
-    pub(in codegen) fn initializers(&self) -> Tokens {
+    pub(in codegen) fn initializers(&self) -> TokenStream {
         let foo = match self.data {
             Data::Enum(_) => panic!("Core loop on enums isn't supported"),
             Data::Struct(ref data) => FieldsGen(data),
@@ -143,7 +143,7 @@ impl<'a> TraitImpl<'a> {
     }
 
     /// Generate the loop which walks meta items looking for property matches.
-    pub(in codegen) fn core_loop(&self) -> Tokens {
+    pub(in codegen) fn core_loop(&self) -> TokenStream {
         let foo = match self.data {
             Data::Enum(_) => panic!("Core loop on enums isn't supported"),
             Data::Struct(ref data) => FieldsGen(data),

--- a/core/src/codegen/variant.rs
+++ b/core/src/codegen/variant.rs
@@ -11,7 +11,7 @@ use usage::{self, IdentRefSet, IdentSet, UsesTypeParams};
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Variant<'a> {
     /// The name which will appear in code passed to the `FromMeta` input.
-    pub name_in_attr: &'a str,
+    pub name_in_attr: String,
 
     /// The name of the variant which will be returned for a given `name_in_attr`.
     pub variant_ident: &'a Ident,
@@ -55,7 +55,7 @@ impl<'a> ToTokens for UnitMatchArm<'a> {
             return;
         }
 
-        let name_in_attr = val.name_in_attr;
+        let name_in_attr = &val.name_in_attr;
 
         if val.data.is_unit() {
             let variant_ident = val.variant_ident;
@@ -82,7 +82,7 @@ impl<'a> ToTokens for DataMatchArm<'a> {
             return;
         }
 
-        let name_in_attr = val.name_in_attr;
+        let name_in_attr = &val.name_in_attr;
         let variant_ident = val.variant_ident;
         let ty_ident = val.ty_ident;
 
@@ -98,7 +98,7 @@ impl<'a> ToTokens for DataMatchArm<'a> {
 
         if val.data.is_struct() {
             let declare_errors = ErrorDeclaration::new();
-            let check_errors = ErrorCheck::with_location(name_in_attr);
+            let check_errors = ErrorCheck::with_location(&name_in_attr);
             let require_fields = vdg.require_fields();
             let decls = vdg.declarations();
             let core_loop = vdg.core_loop();

--- a/core/src/codegen/variant.rs
+++ b/core/src/codegen/variant.rs
@@ -1,4 +1,5 @@
-use quote::{ToTokens, Tokens};
+use proc_macro2::TokenStream;
+use quote::{TokenStreamExt, ToTokens};
 use syn::Ident;
 
 use ast::Fields;
@@ -47,7 +48,7 @@ impl<'a> UsesTypeParams for Variant<'a> {
 pub struct UnitMatchArm<'a>(&'a Variant<'a>);
 
 impl<'a> ToTokens for UnitMatchArm<'a> {
-    fn to_tokens(&self, tokens: &mut Tokens) {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
         let val: &Variant<'a> = self.0;
 
         if val.skip {
@@ -74,7 +75,7 @@ impl<'a> ToTokens for UnitMatchArm<'a> {
 pub struct DataMatchArm<'a>(&'a Variant<'a>);
 
 impl<'a> ToTokens for DataMatchArm<'a> {
-    fn to_tokens(&self, tokens: &mut Tokens) {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
         let val: &Variant<'a> = self.0;
 
         if val.skip {

--- a/core/src/codegen/variant_data.rs
+++ b/core/src/codegen/variant_data.rs
@@ -1,4 +1,4 @@
-use quote::Tokens;
+use proc_macro2::TokenStream;
 
 use ast::Fields;
 use ast::Style;
@@ -8,7 +8,7 @@ use codegen::Field;
 pub struct FieldsGen<'a>(pub &'a Fields<Field<'a>>);
 
 impl<'a> FieldsGen<'a> {
-    pub(in codegen) fn declarations(&self) -> Tokens {
+    pub(in codegen) fn declarations(&self) -> TokenStream {
         match *self.0 {
             Fields {
                 style: Style::Struct,
@@ -22,7 +22,7 @@ impl<'a> FieldsGen<'a> {
     }
 
     /// Generate the loop which walks meta items looking for property matches.
-    pub(in codegen) fn core_loop(&self) -> Tokens {
+    pub(in codegen) fn core_loop(&self) -> TokenStream {
         let arms: Vec<field::MatchArm> = self.0.as_ref().map(Field::as_match).fields;
 
         quote!(
@@ -38,7 +38,7 @@ impl<'a> FieldsGen<'a> {
         )
     }
 
-    pub fn require_fields(&self) -> Tokens {
+    pub fn require_fields(&self) -> TokenStream {
         match *self.0 {
             Fields {
                 style: Style::Struct,
@@ -51,7 +51,7 @@ impl<'a> FieldsGen<'a> {
         }
     }
 
-    pub(in codegen) fn initializers(&self) -> Tokens {
+    pub(in codegen) fn initializers(&self) -> TokenStream {
         let inits: Vec<_> = self.0.as_ref().map(Field::as_initializer).fields;
 
         quote!(#(#inits),*)

--- a/core/src/from_meta.rs
+++ b/core/src/from_meta.rs
@@ -293,7 +293,7 @@ impl<V: FromMeta> FromMeta for HashMap<String, V> {
         for item in nested {
             if let syn::NestedMeta::Meta(ref inner) = *item {
                 match map.entry(inner.name().to_string()) {
-                    Entry::Occupied(_) => return Err(Error::duplicate_field(inner.name().as_ref())),
+                    Entry::Occupied(_) => return Err(Error::duplicate_field(&inner.name().to_string())),
                     Entry::Vacant(entry) => {
                         entry
                             .insert(FromMeta::from_meta(inner)

--- a/core/src/from_meta.rs
+++ b/core/src/from_meta.rs
@@ -311,18 +311,18 @@ impl<V: FromMeta> FromMeta for HashMap<String, V> {
 /// it should not be considered by the parsing.
 #[cfg(test)]
 mod tests {
-    use quote::Tokens;
+    use proc_macro2::TokenStream;
     use syn;
 
     use {FromMeta, Result};
 
     /// parse a string as a syn::Meta instance.
-    fn pm(tokens: Tokens) -> ::std::result::Result<syn::Meta, String> {
+    fn pm(tokens: TokenStream) -> ::std::result::Result<syn::Meta, String> {
         let attribute: syn::Attribute = parse_quote!(#[#tokens]);
         attribute.interpret_meta().ok_or("Unable to parse".into())
     }
 
-    fn fm<T: FromMeta>(tokens: Tokens) -> T {
+    fn fm<T: FromMeta>(tokens: TokenStream) -> T {
         FromMeta::from_meta(&pm(tokens).expect("Tests should pass well-formed input"))
             .expect("Tests should pass valid input")
     }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -37,3 +37,7 @@ pub use from_generics::FromGenerics;
 pub use from_meta::FromMeta;
 pub use from_type_param::FromTypeParam;
 pub use from_variant::FromVariant;
+
+// Re-export tokenizer
+#[doc(hidden)]
+pub use quote::ToTokens;

--- a/core/src/options/core.rs
+++ b/core/src/options/core.rs
@@ -67,7 +67,7 @@ impl Core {
 
 impl ParseAttribute for Core {
     fn parse_nested(&mut self, mi: &syn::Meta) -> Result<()> {
-        match mi.name().as_ref() {
+        match mi.name().to_string().as_str() {
             "default" => {
                 if self.default.is_some() {
                     Err(Error::duplicate_field("default"))

--- a/core/src/options/from_derive.rs
+++ b/core/src/options/from_derive.rs
@@ -50,7 +50,13 @@ impl ParseData for FdiOptions {
     }
 
     fn parse_field(&mut self, field: &syn::Field) -> Result<()> {
-        match field.ident.as_ref().map(|v| v.to_string().as_str()) {
+        match field
+            .ident
+            .as_ref()
+            .map(|v| v.to_string())
+            .as_ref()
+            .map(|v| v.as_str())
+        {
             Some("vis") => {
                 self.vis = field.ident.clone();
                 Ok(())
@@ -72,7 +78,7 @@ impl<'a> From<&'a FdiOptions> for codegen::FromDeriveInputImpl<'a> {
     fn from(v: &'a FdiOptions) -> Self {
         codegen::FromDeriveInputImpl {
             base: (&v.base.container).into(),
-            attr_names: v.base.attr_names.as_strs(),
+            attr_names: &v.base.attr_names,
             from_ident: v.base.from_ident,
             ident: v.base.ident.as_ref(),
             vis: v.vis.as_ref(),

--- a/core/src/options/from_derive.rs
+++ b/core/src/options/from_derive.rs
@@ -34,7 +34,7 @@ impl FdiOptions {
 
 impl ParseAttribute for FdiOptions {
     fn parse_nested(&mut self, mi: &syn::Meta) -> Result<()> {
-        match mi.name().as_ref() {
+        match mi.name().to_string().as_str() {
             "supports" => {
                 self.supports = FromMeta::from_meta(mi)?;
                 Ok(())
@@ -50,7 +50,7 @@ impl ParseData for FdiOptions {
     }
 
     fn parse_field(&mut self, field: &syn::Field) -> Result<()> {
-        match field.ident.as_ref().map(|v| v.as_ref()) {
+        match field.ident.as_ref().map(|v| v.to_string().as_str()) {
             Some("vis") => {
                 self.vis = field.ident.clone();
                 Ok(())

--- a/core/src/options/from_field.rs
+++ b/core/src/options/from_field.rs
@@ -34,7 +34,13 @@ impl ParseData for FromFieldOptions {
     }
 
     fn parse_field(&mut self, field: &syn::Field) -> Result<()> {
-        match field.ident.as_ref().map(|v| v.to_string().as_str()) {
+        match field
+            .ident
+            .as_ref()
+            .map(|v| v.to_string())
+            .as_ref()
+            .map(|v| v.as_str())
+        {
             Some("vis") => {
                 self.vis = field.ident.clone();
                 Ok(())
@@ -56,7 +62,7 @@ impl<'a> From<&'a FromFieldOptions> for FromFieldImpl<'a> {
             ty: v.ty.as_ref(),
             attrs: v.base.attrs.as_ref(),
             base: (&v.base.container).into(),
-            attr_names: v.base.attr_names.as_strs(),
+            attr_names: &v.base.attr_names,
             forward_attrs: v.base.forward_attrs.as_ref(),
             from_ident: v.base.from_ident,
         }

--- a/core/src/options/from_field.rs
+++ b/core/src/options/from_field.rs
@@ -34,7 +34,7 @@ impl ParseData for FromFieldOptions {
     }
 
     fn parse_field(&mut self, field: &syn::Field) -> Result<()> {
-        match field.ident.as_ref().map(|v| v.as_ref()) {
+        match field.ident.as_ref().map(|v| v.to_string().as_str()) {
             Some("vis") => {
                 self.vis = field.ident.clone();
                 Ok(())

--- a/core/src/options/from_type_param.rs
+++ b/core/src/options/from_type_param.rs
@@ -34,7 +34,7 @@ impl ParseData for FromTypeParamOptions {
     }
 
     fn parse_field(&mut self, field: &syn::Field) -> Result<()> {
-        match field.ident.as_ref().map(|v| v.as_ref()) {
+        match field.ident.as_ref().map(|v| v.to_string().as_str()) {
             Some("bounds") => {
                 self.bounds = field.ident.clone();
                 Ok(())

--- a/core/src/options/from_type_param.rs
+++ b/core/src/options/from_type_param.rs
@@ -34,7 +34,13 @@ impl ParseData for FromTypeParamOptions {
     }
 
     fn parse_field(&mut self, field: &syn::Field) -> Result<()> {
-        match field.ident.as_ref().map(|v| v.to_string().as_str()) {
+        match field
+            .ident
+            .as_ref()
+            .map(|v| v.to_string())
+            .as_ref()
+            .map(|v| v.as_str())
+        {
             Some("bounds") => {
                 self.bounds = field.ident.clone();
                 Ok(())
@@ -56,7 +62,7 @@ impl<'a> From<&'a FromTypeParamOptions> for FromTypeParamImpl<'a> {
             attrs: v.base.attrs.as_ref(),
             bounds: v.bounds.as_ref(),
             default: v.default.as_ref(),
-            attr_names: v.base.attr_names.as_strs(),
+            attr_names: &v.base.attr_names,
             forward_attrs: v.base.forward_attrs.as_ref(),
             from_ident: v.base.from_ident,
         }

--- a/core/src/options/from_variant.rs
+++ b/core/src/options/from_variant.rs
@@ -29,7 +29,7 @@ impl<'a> From<&'a FromVariantOptions> for FromVariantImpl<'a> {
             ident: v.base.ident.as_ref(),
             fields: v.fields.as_ref(),
             attrs: v.base.attrs.as_ref(),
-            attr_names: v.base.attr_names.as_strs(),
+            attr_names: &v.base.attr_names,
             forward_attrs: v.base.forward_attrs.as_ref(),
             from_ident: v.base.from_ident,
             supports: v.supports.as_ref(),
@@ -51,7 +51,13 @@ impl ParseAttribute for FromVariantOptions {
 
 impl ParseData for FromVariantOptions {
     fn parse_field(&mut self, field: &Field) -> Result<()> {
-        match field.ident.as_ref().map(|i| i.to_string().as_ref()) {
+        match field
+            .ident
+            .as_ref()
+            .map(|v| v.to_string())
+            .as_ref()
+            .map(|v| v.as_str())
+        {
             Some("fields") => {
                 self.fields = field.ident.clone();
                 Ok(())

--- a/core/src/options/from_variant.rs
+++ b/core/src/options/from_variant.rs
@@ -39,7 +39,7 @@ impl<'a> From<&'a FromVariantOptions> for FromVariantImpl<'a> {
 
 impl ParseAttribute for FromVariantOptions {
     fn parse_nested(&mut self, mi: &Meta) -> Result<()> {
-        match mi.name().as_ref() {
+        match mi.name().to_string().as_str() {
             "supports" => {
                 self.supports = FromMeta::from_meta(mi)?;
                 Ok(())
@@ -51,7 +51,7 @@ impl ParseAttribute for FromVariantOptions {
 
 impl ParseData for FromVariantOptions {
     fn parse_field(&mut self, field: &Field) -> Result<()> {
-        match field.ident.as_ref().map(|i| i.as_ref()) {
+        match field.ident.as_ref().map(|i| i.to_string().as_ref()) {
             Some("fields") => {
                 self.fields = field.ident.clone();
                 Ok(())

--- a/core/src/options/input_field.rs
+++ b/core/src/options/input_field.rs
@@ -83,7 +83,7 @@ impl InputField {
         // explicit renamings take precedence over rename rules on the container,
         // but in the absence of an explicit name we apply the rule.
         if self.attr_name.is_none() {
-            self.attr_name = Some(parent.rename_rule.apply_to_field(&self.ident));
+            self.attr_name = Some(parent.rename_rule.apply_to_field(self.ident.to_string()));
         }
 
         // Determine the default expression for this field, based on three pieces of information:

--- a/core/src/options/input_field.rs
+++ b/core/src/options/input_field.rs
@@ -25,9 +25,8 @@ impl InputField {
         codegen::Field {
             ident: &self.ident,
             name_in_attr: self.attr_name
-                .as_ref()
-                .map(|n| n.as_str())
-                .unwrap_or(self.ident.as_ref()),
+                .clone()
+                .unwrap_or(self.ident.to_string()),
             ty: &self.ty,
             default_expression: self.as_codegen_default(),
             with_path: self.with

--- a/core/src/options/input_variant.rs
+++ b/core/src/options/input_variant.rs
@@ -19,9 +19,8 @@ impl InputVariant {
             ty_ident,
             variant_ident: &self.ident,
             name_in_attr: self.attr_name
-                .as_ref()
-                .map(|s| s.as_str())
-                .unwrap_or(self.ident.as_ref()),
+                .clone()
+                .unwrap_or(self.ident.to_string()),
             data: self.data.as_ref().map(InputField::as_codegen_field),
             skip: self.skip,
         }

--- a/core/src/options/input_variant.rs
+++ b/core/src/options/input_variant.rs
@@ -70,7 +70,7 @@ impl InputVariant {
 
     fn with_inherited(mut self, parent: &Core) -> Self {
         if self.attr_name.is_none() {
-            self.attr_name = Some(parent.rename_rule.apply_to_variant(&self.ident));
+            self.attr_name = Some(parent.rename_rule.apply_to_variant(self.ident.to_string()));
         }
 
         self

--- a/core/src/options/mod.rs
+++ b/core/src/options/mod.rs
@@ -1,4 +1,3 @@
-use proc_macro2::Span;
 use syn;
 
 use {Error, FromMeta, Result};
@@ -44,7 +43,9 @@ impl FromMeta for DefaultExpression {
     }
 
     fn from_string(lit: &str) -> Result<Self> {
-        Ok(DefaultExpression::Explicit(syn::Path::from(syn::Ident::new(lit, Span::call_site()))))
+        Ok(DefaultExpression::Explicit(
+            syn::parse_str(lit).map_err(|_| Error::unknown_value(lit))?
+        ))
     }
 }
 

--- a/core/src/options/mod.rs
+++ b/core/src/options/mod.rs
@@ -1,3 +1,4 @@
+use proc_macro2::Span;
 use syn;
 
 use {Error, FromMeta, Result};
@@ -43,7 +44,7 @@ impl FromMeta for DefaultExpression {
     }
 
     fn from_string(lit: &str) -> Result<Self> {
-        Ok(DefaultExpression::Explicit(syn::Path::from(lit)))
+        Ok(DefaultExpression::Explicit(syn::Path::from(syn::Ident::new(lit, Span::call_site()))))
     }
 }
 

--- a/core/src/options/outer_from.rs
+++ b/core/src/options/outer_from.rs
@@ -65,7 +65,13 @@ impl ParseAttribute for OuterFrom {
 
 impl ParseData for OuterFrom {
     fn parse_field(&mut self, field: &Field) -> Result<()> {
-        match field.ident.as_ref().map(|v| v.to_string().as_ref()) {
+        match field
+            .ident
+            .as_ref()
+            .map(|v| v.to_string())
+            .as_ref()
+            .map(|v| v.as_str())
+        {
             Some("ident") => {
                 self.ident = field.ident.clone();
                 Ok(())

--- a/core/src/options/outer_from.rs
+++ b/core/src/options/outer_from.rs
@@ -42,7 +42,7 @@ impl OuterFrom {
 
 impl ParseAttribute for OuterFrom {
     fn parse_nested(&mut self, mi: &Meta) -> Result<()> {
-        match mi.name().as_ref() {
+        match mi.name().to_string().as_str() {
             "attributes" => {
                 self.attr_names = FromMeta::from_meta(mi)?;
                 Ok(())
@@ -65,7 +65,7 @@ impl ParseAttribute for OuterFrom {
 
 impl ParseData for OuterFrom {
     fn parse_field(&mut self, field: &Field) -> Result<()> {
-        match field.ident.as_ref().map(|v| v.as_ref()) {
+        match field.ident.as_ref().map(|v| v.to_string().as_ref()) {
             Some("ident") => {
                 self.ident = field.ident.clone();
                 Ok(())

--- a/core/src/options/shape.rs
+++ b/core/src/options/shape.rs
@@ -35,7 +35,8 @@ impl FromMeta for Shape {
         let mut new = Shape::default();
         for item in items {
             if let NestedMeta::Meta(Meta::Word(ref ident)) = *item {
-                let word = ident.to_string().as_str();
+                let word = ident.to_string();
+                let word = word.as_str();
                 if word == "any" {
                     new.any = true;
                 } else if word.starts_with("enum_") {

--- a/core/src/options/shape.rs
+++ b/core/src/options/shape.rs
@@ -1,4 +1,5 @@
-use quote::{ToTokens, Tokens};
+use proc_macro2::TokenStream;
+use quote::{TokenStreamExt, ToTokens};
 use syn::{Meta, NestedMeta};
 
 use {Error, FromMeta, Result};
@@ -34,7 +35,7 @@ impl FromMeta for Shape {
         let mut new = Shape::default();
         for item in items {
             if let NestedMeta::Meta(Meta::Word(ref ident)) = *item {
-                let word = ident.as_ref();
+                let word = ident.to_string().as_str();
                 if word == "any" {
                     new.any = true;
                 } else if word.starts_with("enum_") {
@@ -54,7 +55,7 @@ impl FromMeta for Shape {
 }
 
 impl ToTokens for Shape {
-    fn to_tokens(&self, tokens: &mut Tokens) {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
         let fn_body = if self.any == true {
             quote!(::darling::export::Ok(()))
         } else {
@@ -148,7 +149,7 @@ impl FromMeta for DataShape {
         let mut new = DataShape::default();
         for item in items {
             if let NestedMeta::Meta(Meta::Word(ref ident)) = *item {
-                new.set_word(ident.as_ref())?;
+                new.set_word(ident.to_string().as_str())?;
             } else {
                 return Err(Error::unsupported_format("non-word"));
             }
@@ -159,7 +160,7 @@ impl FromMeta for DataShape {
 }
 
 impl ToTokens for DataShape {
-    fn to_tokens(&self, tokens: &mut Tokens) {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
         let body = if self.any {
             quote!(::darling::export::Ok(()))
         } else if self.supports_none() {
@@ -194,7 +195,7 @@ impl ToTokens for DataShape {
     }
 }
 
-fn match_arm(name: &'static str, is_supported: bool) -> Tokens {
+fn match_arm(name: &'static str, is_supported: bool) -> TokenStream {
     if is_supported {
         quote!(::darling::export::Ok(()))
     } else {
@@ -204,19 +205,19 @@ fn match_arm(name: &'static str, is_supported: bool) -> Tokens {
 
 #[cfg(test)]
 mod tests {
-    use quote::Tokens;
+    use proc_macro2::TokenStream;
     use syn;
 
     use super::Shape;
     use FromMeta;
 
     /// parse a string as a syn::Meta instance.
-    fn pm(tokens: Tokens) -> ::std::result::Result<syn::Meta, String> {
+    fn pm(tokens: TokenStream) -> ::std::result::Result<syn::Meta, String> {
         let attribute: syn::Attribute = parse_quote!(#[#tokens]);
         attribute.interpret_meta().ok_or("Unable to parse".into())
     }
 
-    fn fm<T: FromMeta>(tokens: Tokens) -> T {
+    fn fm<T: FromMeta>(tokens: TokenStream) -> T {
         FromMeta::from_meta(&pm(tokens).expect("Tests should pass well-formed input"))
             .expect("Tests should pass valid input")
     }

--- a/core/src/usage/lifetimes.rs
+++ b/core/src/usage/lifetimes.rs
@@ -22,6 +22,14 @@ pub trait UsesLifetimes {
         options: &Options,
         lifetimes: &'a LifetimeSet,
     ) -> LifetimeRefSet<'a>;
+
+    /// Find all used lifetimes, then clone them and return that set.
+    fn uses_lifetimes_cloned(&self, options: &Options, lifetimes: &LifetimeSet) -> LifetimeSet {
+        self.uses_lifetimes(options, lifetimes)
+            .into_iter()
+            .cloned()
+            .collect()
+}
 }
 
 /// Searcher for finding lifetimes in an iterator.
@@ -35,6 +43,9 @@ pub trait CollectLifetimes {
         options: &Options,
         lifetimes: &'a LifetimeSet,
     ) -> LifetimeRefSet<'a>;
+
+    /// Consume an iterator using `collect_lifetimes`, then clone all found lifetimes and return that set.
+    fn collect_lifetimes_cloned(self, options: &Options, lifetimes: &LifetimeSet) -> LifetimeSet;
 }
 
 impl<'i, I, T> CollectLifetimes for T
@@ -52,6 +63,13 @@ where
                 state.extend(value.uses_lifetimes(options, lifetimes));
                 state
             })
+    }
+
+    fn collect_lifetimes_cloned(self, options: &Options, lifetimes: &LifetimeSet) -> LifetimeSet {
+        self.collect_lifetimes(options, lifetimes)
+            .into_iter()
+            .cloned()
+            .collect()
     }
 }
 

--- a/core/src/usage/lifetimes.rs
+++ b/core/src/usage/lifetimes.rs
@@ -29,7 +29,7 @@ pub trait UsesLifetimes {
             .into_iter()
             .cloned()
             .collect()
-}
+    }
 }
 
 /// Searcher for finding lifetimes in an iterator.

--- a/core/src/usage/type_params.rs
+++ b/core/src/usage/type_params.rs
@@ -18,7 +18,7 @@ pub trait UsesTypeParams {
             .into_iter()
             .cloned()
             .collect()
-}
+    }
 }
 
 /// Searcher for finding type params in an iterator.
@@ -50,7 +50,7 @@ where
             .into_iter()
             .cloned()
             .collect()
-}
+    }
 }
 
 /// Insert the contents of `right` into `left`.
@@ -243,6 +243,7 @@ impl UsesTypeParams for syn::TypeParamBound {
 
 #[cfg(test)]
 mod tests {
+    use proc_macro2::Span;
     use syn::{self, Ident};
 
     use super::UsesTypeParams;
@@ -254,7 +255,10 @@ mod tests {
     }
 
     fn ident_set(idents: Vec<&str>) -> IdentSet {
-        idents.into_iter().map(Ident::from).collect()
+        idents
+            .into_iter()
+            .map(|s| Ident::new(s, Span::call_site()))
+            .collect()
     }
 
     #[test]
@@ -263,10 +267,10 @@ mod tests {
         let generics = ident_set(vec!["T", "U", "X"]);
         let matches = input.data.uses_type_params(&BoundImpl.into(), &generics);
         assert_eq!(matches.len(), 2);
-        assert!(matches.contains(&Ident::from("T")));
-        assert!(matches.contains(&Ident::from("U")));
-        assert!(!matches.contains(&Ident::from("X")));
-        assert!(!matches.contains(&Ident::from("A")));
+        assert!(matches.contains::<Ident>(&parse_quote!(T)));
+        assert!(matches.contains::<Ident>(&parse_quote!(U)));
+        assert!(!matches.contains::<Ident>(&parse_quote!(X)));
+        assert!(!matches.contains::<Ident>(&parse_quote!(A)));
     }
 
     #[test]
@@ -285,10 +289,10 @@ mod tests {
         let matches = input.data.uses_type_params(&BoundImpl.into(), &generics);
 
         assert_eq!(matches.len(), 2);
-        assert!(matches.contains(&Ident::from("T")));
-        assert!(matches.contains(&Ident::from("U")));
-        assert!(!matches.contains(&Ident::from("X")));
-        assert!(!matches.contains(&Ident::from("A")));
+        assert!(matches.contains::<Ident>(&parse_quote!(T)));
+        assert!(matches.contains::<Ident>(&parse_quote!(U)));
+        assert!(!matches.contains::<Ident>(&parse_quote!(X)));
+        assert!(!matches.contains::<Ident>(&parse_quote!(A)));
     }
 
     #[test]
@@ -307,10 +311,10 @@ mod tests {
         let matches = input.data.uses_type_params(&BoundImpl.into(), &generics);
 
         assert_eq!(matches.len(), 2);
-        assert!(matches.contains(&Ident::from("T")));
-        assert!(matches.contains(&Ident::from("U")));
-        assert!(!matches.contains(&Ident::from("X")));
-        assert!(!matches.contains(&Ident::from("A")));
+        assert!(matches.contains::<Ident>(&parse_quote!(T)));
+        assert!(matches.contains::<Ident>(&parse_quote!(U)));
+        assert!(!matches.contains::<Ident>(&parse_quote!(X)));
+        assert!(!matches.contains::<Ident>(&parse_quote!(A)));
     }
 
     #[test]
@@ -327,7 +331,7 @@ mod tests {
         let generics = ident_set(vec!["T"]);
         let matches = input.data.uses_type_params(&BoundImpl.into(), &generics);
         assert_eq!(matches.len(), 1);
-        assert!(matches.contains(&Ident::from("T")));
+        assert!(matches.contains::<Ident>(&parse_quote!(T)));
     }
 
     #[test]
@@ -336,7 +340,7 @@ mod tests {
         let generics = ident_set(vec!["T"]);
         let matches = input.data.uses_type_params(&BoundImpl.into(), &generics);
         assert_eq!(matches.len(), 1);
-        assert!(matches.contains(&Ident::from("T")));
+        assert!(matches.contains::<Ident>(&parse_quote!(T)));
     }
 
     /// Test that `syn::TypePath` is correctly honoring the different modes a
@@ -351,6 +355,6 @@ mod tests {
 
         let declare_matches = input.data.uses_type_params(&Declare.into(), &generics);
         assert_eq!(declare_matches.len(), 1);
-        assert!(declare_matches.contains(&Ident::from("T")));
+        assert!(declare_matches.contains::<Ident>(&parse_quote!(T)));
     }
 }

--- a/core/src/usage/type_params.rs
+++ b/core/src/usage/type_params.rs
@@ -11,6 +11,14 @@ pub trait UsesTypeParams {
     /// This method only accounts for direct usage by the element; indirect usage via bounds or `where`
     /// predicates are not detected.
     fn uses_type_params<'a>(&self, options: &Options, type_set: &'a IdentSet) -> IdentRefSet<'a>;
+
+    /// Find all type params using `uses_type_params`, then clone the found values and return the set.
+    fn uses_type_params_cloned(&self, options: &Options, type_set: &IdentSet) -> IdentSet {
+        self.uses_type_params(options, type_set)
+            .into_iter()
+            .cloned()
+            .collect()
+}
 }
 
 /// Searcher for finding type params in an iterator.
@@ -20,6 +28,9 @@ pub trait UsesTypeParams {
 pub trait CollectTypeParams {
     /// Consume an iterator, accumulating all type parameters in the elements which occur in `type_set`.
     fn collect_type_params<'a>(self, options: &Options, type_set: &'a IdentSet) -> IdentRefSet<'a>;
+
+    /// Consume an iterator using `collect_type_params`, then clone all found type params and return that set.
+    fn collect_type_params_cloned(self, options: &Options, type_set: &IdentSet) -> IdentSet;
 }
 
 impl<'i, T, I> CollectTypeParams for T
@@ -33,6 +44,13 @@ where
             |state, value| union_in_place(state, value.uses_type_params(options, type_set)),
         )
     }
+
+    fn collect_type_params_cloned(self, options: &Options, type_set: &IdentSet) -> IdentSet {
+        self.collect_type_params(options, type_set)
+            .into_iter()
+            .cloned()
+            .collect()
+}
 }
 
 /// Insert the contents of `right` into `left`.

--- a/core/src/util/ident_list.rs
+++ b/core/src/util/ident_list.rs
@@ -1,4 +1,5 @@
 use std::ops::Deref;
+use std::string::ToString;
 
 use syn::{Ident, Meta, NestedMeta};
 
@@ -24,9 +25,9 @@ impl IdentList {
         IdentList(vals.into_iter().map(T::into).collect())
     }
 
-    /// Creates a view of the contained identifiers as `&str`s.
-    pub fn as_strs<'a>(&'a self) -> Vec<&'a str> {
-        self.iter().map(|i| i.as_ref()).collect()
+    /// Create a new `Vec` containing the string representation of each ident.
+    pub fn to_strings(&self) -> Vec<String> {
+        self.0.iter().map(ToString::to_string).collect()
     }
 }
 

--- a/core/src/util/ident_string.rs
+++ b/core/src/util/ident_string.rs
@@ -1,0 +1,148 @@
+use std::fmt;
+
+use proc_macro2::{Span, TokenStream};
+use quote::ToTokens;
+use syn::{Ident, Meta};
+
+use {FromMeta, Result};
+
+/// A wrapper for an `Ident` which also keeps the value as a string.
+///
+/// This struct can be used to perform string comparisons and operations.
+#[derive(Clone, Hash, PartialOrd, Ord)]
+pub struct IdentString {
+    ident: Ident,
+    string: String,
+}
+
+impl IdentString {
+    /// Create a new `IdentString`.
+    pub fn new(ident: Ident) -> Self {
+        IdentString {
+            string: ident.to_string(),
+            ident,
+        }
+    }
+
+    /// Get the ident as a `proc_macro2::Ident`.
+    pub fn as_ident(&self) -> &Ident {
+        &self.ident
+    }
+
+    /// Get the ident as a string.
+    pub fn as_str(&self) -> &str {
+        &self.string
+    }
+
+    /// Get the location of this `Ident` in source.
+    pub fn span(&self) -> Span {
+        self.ident.span()
+    }
+
+    /// Apply some transform to the ident's string representation.
+    ///
+    /// # Panics
+    /// This will panic if the transform produces an invalid ident.
+    pub fn map<F, S>(self, map_fn: F) -> Self
+    where
+        F: FnOnce(String) -> S,
+        S: AsRef<str>,
+    {
+        let span = self.span();
+        let string = map_fn(self.string);
+        Ident::new(string.as_ref(), span).into()
+    }
+}
+
+impl AsRef<Ident> for IdentString {
+    fn as_ref(&self) -> &Ident {
+        self.as_ident()
+    }
+}
+
+impl AsRef<str> for IdentString {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl From<Ident> for IdentString {
+    fn from(ident: Ident) -> Self {
+        IdentString::new(ident)
+    }
+}
+
+impl From<IdentString> for Ident {
+    fn from(v: IdentString) -> Ident {
+        v.ident
+    }
+}
+
+impl From<IdentString> for String {
+    fn from(v: IdentString) -> String {
+        v.string
+    }
+}
+
+impl Eq for IdentString {}
+
+impl PartialEq for IdentString {
+    fn eq(&self, rhs: &Self) -> bool {
+        self.ident == rhs.ident
+    }
+}
+
+impl PartialEq<String> for IdentString {
+    fn eq(&self, rhs: &String) -> bool {
+        self.as_str() == rhs
+    }
+}
+
+impl<'a> PartialEq<&'a str> for IdentString {
+    fn eq(&self, rhs: &&str) -> bool {
+        self.as_str() == *rhs
+    }
+}
+
+impl ToTokens for IdentString {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        self.ident.to_tokens(tokens);
+    }
+}
+
+impl fmt::Debug for IdentString {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self.ident)
+    }
+}
+
+impl fmt::Display for IdentString {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.ident)
+    }
+}
+
+impl FromMeta for IdentString {
+    fn from_meta(item: &Meta) -> Result<Self> {
+        Ident::from_meta(item).map(IdentString::from)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::IdentString;
+
+    #[test]
+    fn convert() {
+        let i_str = IdentString::new(parse_quote!(t));
+        assert_eq!(i_str.as_str(), "t");
+    }
+
+    #[test]
+    fn map_transform() {
+        let i = IdentString::new(parse_quote!(my));
+        let after = i.map(|v| format!("var_{}", v));
+        assert_eq!(after, "var_my");
+        assert_eq!(after, String::from("var_my"));
+    }
+}

--- a/core/src/util/mod.rs
+++ b/core/src/util/mod.rs
@@ -6,11 +6,13 @@ use syn;
 use {FromMeta, Result};
 
 mod ident_list;
+mod ident_string;
 mod ignored;
 mod over_ride;
 mod with_original;
 
 pub use self::ident_list::IdentList;
+pub use self::ident_string::IdentString;
 pub use self::ignored::Ignored;
 pub use self::over_ride::Override;
 pub use self::with_original::WithOriginal;

--- a/examples/consume_fields.rs
+++ b/examples/consume_fields.rs
@@ -2,14 +2,15 @@
 
 #[macro_use]
 extern crate darling;
-
+extern crate proc_macro2;
 #[macro_use]
 extern crate quote;
 extern crate syn;
 
 use darling::ast;
 use darling::FromDeriveInput;
-use quote::{ToTokens, Tokens};
+use proc_macro2::TokenStream;
+use quote::ToTokens;
 use syn::parse_str;
 
 /// A speaking volume. Deriving `FromMeta` will cause this to be usable
@@ -54,7 +55,7 @@ struct MyInputReceiver {
 }
 
 impl ToTokens for MyInputReceiver {
-    fn to_tokens(&self, tokens: &mut Tokens) {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
         let MyInputReceiver {
             ref ident,
             ref generics,
@@ -80,7 +81,7 @@ impl ToTokens for MyInputReceiver {
                     "{} = {{}}",
                     f.ident
                         .as_ref()
-                        .map(|v| format!("{}", v),)
+                        .map(|v| format!("{}", v))
                         .unwrap_or_else(|| format!("{}", i))
                 )
             })
@@ -113,7 +114,7 @@ impl ToTokens for MyInputReceiver {
             })
             .collect::<Vec<_>>();
 
-        tokens.append_all(quote! {
+        tokens.extend(quote! {
             impl #imp Speak for #ident #ty #wher {
                 fn speak(&self, writer: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
                     write!(#fmt_string, #(#field_list),*)

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -10,8 +10,8 @@ implementing custom derives. Use https://crates.io/crates/darling in your code.
 license = "MIT"
 
 [dependencies]
-quote = "0.5"
-syn = "0.13"
+quote = "0.6"
+syn = "0.14"
 darling_core = { version = "=0.6.3", path = "../core" }
 
 [lib]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,9 @@ pub use darling_core::{Error, Result};
 #[doc(inline)]
 pub use darling_core::{ast, error, usage, util};
 
+#[doc(hidden)]
+pub use darling_core::ToTokens;
+
 /// Core/std trait re-exports. This should help produce generated code which doesn't
 /// depend on `std` unnecessarily, and avoids problems caused by aliasing `std` or any
 /// of the referenced types.
@@ -86,6 +89,7 @@ pub mod export {
     pub use core::option::Option::{self, None, Some};
     pub use core::result::Result::{self, Err, Ok};
     pub use std::vec::Vec;
+    pub use std::string::ToString;
 }
 
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,8 @@ pub use darling_core::{Error, Result};
 #[doc(inline)]
 pub use darling_core::{ast, error, usage, util};
 
+// XXX exported so that `ExtractAttribute::extractor` can convert a path into tokens.
+// This is likely to change in the future, so only generated code should depend on this export.
 #[doc(hidden)]
 pub use darling_core::ToTokens;
 

--- a/tests/defaults.rs
+++ b/tests/defaults.rs
@@ -1,0 +1,32 @@
+#[macro_use]
+extern crate darling;
+#[macro_use]
+extern crate quote;
+#[macro_use]
+extern crate syn;
+
+use darling::FromDeriveInput;
+
+mod foo {
+    pub mod bar {
+        pub fn init() -> String {
+            String::from("hello")
+        }
+    }
+}
+
+#[derive(FromDeriveInput)]
+#[darling(attributes(speak))]
+pub struct SpeakerOpts {
+    #[darling(default="foo::bar::init")]
+    first_word: String,
+}
+
+#[test]
+fn path_default() {
+    let speaker: SpeakerOpts = FromDeriveInput::from_derive_input(&parse_quote! {
+        struct Foo;
+    }).expect("Unit struct with no attrs should parse");
+
+    assert_eq!(speaker.first_word, "hello");
+}

--- a/tests/from_generics.rs
+++ b/tests/from_generics.rs
@@ -61,7 +61,7 @@ fn expand_some() {
         .expect("type_params should not be empty");
     assert!(first.bar.is_none());
     assert!(first.foo);
-    assert_eq!(first.ident.as_ref(), "T");
+    assert_eq!(first.ident, "T");
 
     let second = ty_param_iter
         .next()
@@ -74,7 +74,7 @@ fn expand_some() {
         "x"
     );
     assert_eq!(second.foo, false);
-    assert_eq!(second.ident.as_ref(), "U");
+    assert_eq!(second.ident, "U");
 }
 
 /// Verify ≤0.4.1 behavior - where `generics` had to be `syn::Generics` - keeps working.
@@ -149,15 +149,14 @@ fn with_original() {
         .expect("Second argument should be type param");
 
     // Make sure the first type param in each case is T
-    assert_eq!(parsed_t.ident.as_ref(), "T");
+    assert_eq!(parsed_t.ident, "T");
     assert_eq!(
         rec.generics
             .original
             .type_params()
             .next()
             .expect("First type param should exist")
-            .ident
-            .as_ref(),
+            .ident,
         "T"
     );
 

--- a/tests/from_type_param.rs
+++ b/tests/from_type_param.rs
@@ -47,7 +47,7 @@ fn expand_many() {
     {
         let ty = extract_type(&params[0]);
         let lorem = Lorem::from_type_param(ty).unwrap();
-        assert_eq!(lorem.ident.as_ref(), "T");
+        assert_eq!(lorem.ident, "T");
         assert_eq!(lorem.foo, true);
         assert_eq!(lorem.bar, None);
     }
@@ -55,7 +55,7 @@ fn expand_many() {
     {
         let ty = extract_type(&params[1]);
         let lorem = Lorem::from_type_param(ty).unwrap();
-        assert_eq!(lorem.ident.as_ref(), "U");
+        assert_eq!(lorem.ident, "U");
         assert_eq!(lorem.foo, false);
         assert_eq!(lorem.bar, Some("x".to_string()));
         assert_eq!(lorem.bounds.len(), 2);

--- a/tests/happy_path.rs
+++ b/tests/happy_path.rs
@@ -45,7 +45,7 @@ fn simple() {
     assert_eq!(
         Core::from_derive_input(&di).unwrap(),
         Core {
-            ident: syn::Ident::from("Bar"),
+            ident: parse_quote!(Bar),
             vis: parse_quote!(pub),
             generics: Default::default(),
             lorem: Lorem {
@@ -69,7 +69,7 @@ fn trait_type() {
     assert_eq!(
         TraitCore::from_derive_input(&di).unwrap(),
         TraitCore {
-            ident: syn::Ident::from("Bar"),
+            ident: parse_quote!(Bar),
             generics: Default::default(),
             lorem: Lorem {
                 ipsum: false,


### PR DESCRIPTION
I've split the changes into 3 commits:
1. The main part of this PR:
   * List of breaking changes from [`proc-macro2`](https://github.com/alexcrichton/proc-macro2/releases/tag/0.4.0), [`quote`](https://github.com/dtolnay/quote/releases/tag/0.6.0) and [`syn`](https://github.com/dtolnay/syn/releases/tag/0.14.0).
   * Replacing `quote::Tokens` with `proc_macro2::TokenStream` + `quote::TokenStreamExt` was easy.
   * Updating to the new `Ident` was far more tricky because both `impl AsRef<str>` and `impl Copy` are gone -- now you can't pass around `Ident`s without thinking about ownership and comparing to strings incurs heap allocation overhead (even `impl<T: AsRef<str> + ?Sized> PartialEq<T>` [uses `.to_string()` underneath](https://github.com/alexcrichton/proc-macro2/pull/92/files)).
   * The build in this PR produces the following error message:
     <details>
     <summary>Output from cargo +1.18.0 build</summary>

     ```sh
     error[E0271]: type mismatch resolving `<std::collections::HashSet<&proc_macro2::Ident, std::hash::BuildHasherDefault<fnv::FnvHasher>> as std::iter::IntoIterator>::Item == proc_macro2::Ident`
       --> core/src/codegen/trait_impl.rs:72:14
        |
     72 |         hits.extend(
        |              ^^^^^^ expected reference, found struct `proc_macro2::Ident`
        |
        = note: expected type `&proc_macro2::Ident`
                   found type `proc_macro2::Ident`

     error: no method named `as_ref` found for type `proc_macro2::Ident` in the current scope
       --> core/src/options/input_field.rs:30:39
        |
     30 |                 .unwrap_or(self.ident.as_ref()),
        |                                       ^^^^^^

     error: no method named `as_ref` found for type `proc_macro2::Ident` in the current scope
       --> core/src/options/input_variant.rs:24:39
        |
     24 |                 .unwrap_or(self.ident.as_ref()),
        |                                       ^^^^^^

     error: no method named `as_ref` found for type `&proc_macro2::Ident` in the current scope
       --> core/src/util/ident_list.rs:29:31
        |
     29 |         self.iter().map(|i| i.as_ref()).collect()
        |                               ^^^^^^
        |
        = note: the method `as_ref` exists but the following trait bounds were not satisfied: `proc_macro2::Ident : std::convert::AsRef<_>`

     error: aborting due to 4 previous errors

     error: Could not compile `darling_core`.
     ```
     </details>

     I _believe_ that to resolve this on my behalf I would need to dig further and make fundamental changes in the API. I'm not comfortable to do so, for being afraid to mess up the logic, though if you think that would be easy to do, I'll probably try. Also, I might be totally wrong and just overthinking the complexity of this library :smile:.
2. Implement `"proc-macro"` feature propagation for `darling_core` so that there was a way to be dependency-free from `rustc`-related libraries. Since `darling_macro` directly depends on libproc_macro and `darling ` is just a re-export facade (and so indirectly depends on libproc_macro), they didn't get the same treatment.
3. Miscellaneous improvements to developer's workflow and stability guarantees regarding Rust compiler version -- now CI tracks Rust 1.18.

With that said, please make a thorough review and suggest ideas/criticize where appropriate!

Closes https://github.com/TedDriggs/darling/issues/38.