### PR TITLE
Diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.8.4
+- Use `syn::Error` to provide precise errors before `proc_macro::Diagnostic` is available
+- Add `diagnostics` feature flag to toggle between stable and unstable error backends
+- Attach error information in more contexts
+
 ## v0.8.3 (January 21, 2019)
 - Attach spans to errors in generated trait impls [#37](https://github.com/darling/issues/37)
 - Attach spans to errors for types with provided bespoke implementations

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,10 @@ darling_macro = { version = "=0.8.3", path = "macro" }
 [dev-dependencies]
 proc-macro2 = "0.4"
 quote = "0.6"
-syn = "0.15"
+syn = "0.15.26"
+
+[features]
+diagnostics = [ "darling_core/diagnostics" ]
 
 [workspace]
 members = ["macro", "core"]

--- a/README.md
+++ b/README.md
@@ -55,4 +55,4 @@ Darling's features are built to work well for real-world projects.
 * **Mapping function**: Use `#[darling(map="path")]` to specify a function that runs on the result of parsing a meta-item field. This can change the return type, which enables you to parse to an intermediate form and convert that to the type you need in your struct.
 * **Skip fields**: Use `#[darling(skip)]` to mark a field that shouldn't be read from attribute meta-items.
 * **Multiple-occurrence fields**: Use `#[darling(multiple)]` on a `Vec` field to allow that field to appear multiple times in the meta-item. Each occurrence will be pushed into the `Vec`.
-* **Span access**: Use `darling::util::SpannedValue` in a struct to get access to that meta item's source code span. This can be used to emit warnings that point at a specific field from your proc macro.
+* **Span access**: Use `darling::util::SpannedValue` in a struct to get access to that meta item's source code span. This can be used to emit warnings that point at a specific field from your proc macro. In addition, you can use `darling::Error::write_errors` to automatically get precise error location details in most cases.

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -13,10 +13,11 @@ license = "MIT"
 # temporary hack to make Racer autocomplete work; it requires a 3-part version
 # number and doesn't allow for any feature declarations.
 default = ["syn/full"]
+diagnostics = []
 
 [dependencies]
 ident_case = "1.0.0"
-proc-macro2 = "0.4.2"
+proc-macro2 = "0.4.26"
 quote = "0.6"
-syn = { version = "0.15", features = ["extra-traits"] }
+syn = { version = "0.15.26", features = ["extra-traits"] }
 fnv = "1.0.6"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,14 +1,15 @@
 #![recursion_limit = "256"]
+#![cfg_attr(feature = "diagnostics", feature(proc_macro_diagnostic))]
 
 #[macro_use]
 extern crate quote;
-
 #[macro_use]
 extern crate syn;
-extern crate proc_macro2;
-
 extern crate fnv;
 extern crate ident_case;
+#[cfg(feature = "diagnostics")]
+extern crate proc_macro;
+extern crate proc_macro2;
 
 #[macro_use]
 mod macros_private;

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 
 [dependencies]
 quote = "0.6"
-syn = "0.15"
+syn = "0.15.26"
 darling_core = { version = "=0.8.3", path = "../core" }
 
 [lib]


### PR DESCRIPTION
Add diagnostics behind a feature flag, and enable `syn` when the compiler diagnostics aren't available.