### PR TITLE
Improve error messages for unknown literal types.

### DIFF
--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -7,6 +7,7 @@ use std::iter::{self, Iterator};
 use std::string::ToString;
 use std::vec;
 use syn::spanned::Spanned;
+use syn::Lit;
 
 /// An alias of `Result` specific to attribute parsing.
 pub type Result<T> = ::std::result::Result<T, Error>;
@@ -67,6 +68,21 @@ impl Error {
     /// Creates a new error for a field which has an unexpected literal type.
     pub fn unexpected_type(ty: &str) -> Self {
         Error::new(ErrorKind::UnexpectedType(ty.into()))
+    }
+
+    /// Creates a new error for a field which has an unexpected literal type. This will automatically
+    /// extract the literal type name from the passed-in `Lit`.
+    pub fn unexpected_lit_type(lit: &Lit) -> Self {
+        Error::unexpected_type(match *lit {
+            Lit::Str(_) => "string",
+            Lit::ByteStr(_) => "byte string",
+            Lit::Byte(_) => "byte",
+            Lit::Char(_) => "char",
+            Lit::Int(_) => "int",
+            Lit::Float(_) => "float",
+            Lit::Bool(_) => "bool",
+            Lit::Verbatim(_) => "verbatim",
+        })
     }
 
     /// Creates a new error for a value which doesn't match a set of expected literals.

--- a/core/src/from_meta.rs
+++ b/core/src/from_meta.rs
@@ -92,7 +92,7 @@ pub trait FromMeta: Sized {
         (match *value {
             Lit::Bool(ref b) => Self::from_bool(b.value),
             Lit::Str(ref s) => Self::from_string(&s.value()),
-            ref _other => Err(Error::unexpected_type("other")),
+            _ => Err(Error::unexpected_lit_type(value)),
         })
         .map_err(|e| e.with_span(value))
     }


### PR DESCRIPTION
Literals that aren't contextually accepted will now state their exact type, rather than "other".

This also allows for easier implementations of `FromMeta::from_value`, and will be used by #52.