### PR TITLE
Add "did you mean" suggestions for fields behind a feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+- Added "did you mean" suggestions for unknown fields behind the `suggestions` flag [#60](https://github.com/TedDriggs/issues/60)
+- Added `Error::unknown_field_with_alts` to support the suggestion use-case.
+- Added `ast::Fields::len` and `ast::Fields::is_empty` methods.
+
 ## v0.8.5 (February 4, 2019)
 - Accept unquoted positive numeric literals [#52](https://github.com/TedDriggs/issues/52)
 - Add `FromMeta` to the `syn::Lit` enum and its variants

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ syn = "0.15.26"
 
 [features]
 diagnostics = [ "darling_core/diagnostics" ]
+suggestions = [ "darling_core/suggestions" ]
 
 [workspace]
 members = ["macro", "core"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,6 +14,7 @@ license = "MIT"
 # number and doesn't allow for any feature declarations.
 default = ["syn/full"]
 diagnostics = []
+suggestions = ["strsim"]
 
 [dependencies]
 ident_case = "1.0.0"
@@ -21,3 +22,4 @@ proc-macro2 = "0.4.26"
 quote = "0.6"
 syn = { version = "0.15.26", features = ["extra-traits"] }
 fnv = "1.0.6"
+strsim = { version = "0.8.0", optional = true }

--- a/core/src/ast/data.rs
+++ b/core/src/ast/data.rs
@@ -178,7 +178,7 @@ impl<T> Fields<T> {
 
     /// Returns true if this variant's data makes it a newtype.
     pub fn is_newtype(&self) -> bool {
-        self.style == Style::Tuple && self.fields.len() == 1
+        self.style == Style::Tuple && self.len() == 1
     }
 
     pub fn is_unit(&self) -> bool {
@@ -212,6 +212,16 @@ impl<T> Fields<T> {
 
     pub fn iter(&self) -> slice::Iter<T> {
         self.fields.iter()
+    }
+
+    /// Returns the number of fields in the structure.
+    pub fn len(&self) -> usize {
+        self.fields.len()
+    }
+
+    /// Returns `true` if the `Fields` contains no fields.
+    pub fn is_empty(&self) -> bool {
+        self.fields.is_empty()
     }
 }
 

--- a/core/src/codegen/field.rs
+++ b/core/src/codegen/field.rs
@@ -29,6 +29,10 @@ pub struct Field<'a> {
 }
 
 impl<'a> Field<'a> {
+    pub fn as_name(&'a self) -> &'a str {
+        &self.name_in_attr
+    }
+
     pub fn as_declaration(&'a self) -> Declaration<'a> {
         Declaration(self, !self.skip)
     }

--- a/core/src/codegen/variant_data.rs
+++ b/core/src/codegen/variant_data.rs
@@ -40,9 +40,17 @@ impl<'a> FieldsGen<'a> {
         let handle_unknown = if self.allow_unknown_fields {
             quote!()
         } else {
-            let names = self.fields.as_ref().map(Field::as_name);
+            // We can't call `unknown_field_with_alts` with an empty slice, or else it fails to
+            // infer the type of the slice item.
+            let err_fn = if arms.is_empty() {
+                quote!(unknown_field(__other))
+            } else {
+                let names = self.fields.as_ref().map(Field::as_name);
+                quote!(unknown_field_with_alts(__other, &[#(#names),*]))
+            };
+
             quote! {
-                __errors.push(::darling::Error::unknown_field_with_alts(__other, &[#(#names),*]).with_span(__inner));
+                __errors.push(::darling::Error::#err_fn.with_span(__inner));
             }
         };
 

--- a/core/src/codegen/variant_data.rs
+++ b/core/src/codegen/variant_data.rs
@@ -40,8 +40,9 @@ impl<'a> FieldsGen<'a> {
         let handle_unknown = if self.allow_unknown_fields {
             quote!()
         } else {
+            let names = self.fields.as_ref().map(Field::as_name);
             quote! {
-                __errors.push(::darling::Error::unknown_field(__other).with_span(__inner));
+                __errors.push(::darling::Error::unknown_field_with_alts(__other, &[#(#names),*]).with_span(__inner));
             }
         };
 

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -56,6 +56,21 @@ impl Error {
         Error::new(ErrorKind::UnknownField(name.into()))
     }
 
+    /// Creates a new error for a field name that appears in the input but does not correspond to
+    /// a known attribute. The second argument is the list of known attributes; if a similar name
+    /// is found that will be shown in the emitted error message.
+    pub fn unknown_field_with_alts<'a, T, I>(field: &str, alternates: I) -> Self
+    where
+        T: AsRef<str> + 'a,
+        I: IntoIterator<Item = &'a T>,
+    {
+        let did_you_mean = did_you_mean(field, alternates);
+        Error::new(ErrorKind::UnknownField(ErrorUnknownField::new(
+            field,
+            did_you_mean,
+        )))
+    }
+
     /// Creates a new error for a struct or variant that does not adhere to the supported shape.
     pub fn unsupported_shape(shape: &str) -> Self {
         Error::new(ErrorKind::UnsupportedShape(shape.into()))
@@ -109,7 +124,8 @@ impl Error {
             Lit::Float(_) => "float",
             Lit::Bool(_) => "bool",
             Lit::Verbatim(_) => "verbatim",
-        }).with_span(lit)
+        })
+        .with_span(lit)
     }
 
     /// Creates a new error for a value which doesn't match a set of expected literals.
@@ -285,11 +301,16 @@ impl Error {
     fn single_to_diagnostic(self) -> ::proc_macro::Diagnostic {
         use proc_macro::{Diagnostic, Level};
 
+        // Delegate to dedicated error formatters when applicable.
+        //
         // If span information is available, don't include the error property path
         // since it's redundant and not consistent with native compiler diagnostics.
-        match self.span {
-            Some(span) => span.unwrap().error(self.kind.to_string()),
-            None => Diagnostic::new(Level::Error, self.to_string()),
+        match self.kind {
+            ErrorKind::UnknownField(euf) => euf.to_diagnostic(self.span),
+            kind => match self.span {
+                Some(span) => span.unwrap().error(kind.to_string()),
+                None => Diagnostic::new(Level::Error, self.to_string()),
+            }
         }
     }
 
@@ -426,7 +447,7 @@ enum ErrorKind {
     DuplicateField(FieldName),
     MissingField(FieldName),
     UnsupportedShape(DeriveInputShape),
-    UnknownField(FieldName),
+    UnknownField(ErrorUnknownField),
     UnexpectedFormat(MetaFormat),
     UnexpectedType(String),
     UnknownValue(String),
@@ -478,7 +499,7 @@ impl fmt::Display for ErrorKind {
             Custom(ref s) => s.fmt(f),
             DuplicateField(ref field) => write!(f, "Duplicate field `{}`", field),
             MissingField(ref field) => write!(f, "Missing field `{}`", field),
-            UnknownField(ref field) => write!(f, "Unexpected field `{}`", field),
+            UnknownField(ref field) => field.fmt(f),
             UnsupportedShape(ref shape) => write!(f, "Unsupported shape `{}`", shape),
             UnexpectedFormat(ref format) => write!(f, "Unexpected meta-item format `{}`", format),
             UnexpectedType(ref ty) => write!(f, "Unexpected literal type `{}`", ty),
@@ -504,6 +525,99 @@ impl fmt::Display for ErrorKind {
             __NonExhaustive => unreachable!(),
         }
     }
+}
+
+impl From<ErrorUnknownField> for ErrorKind {
+    fn from(err: ErrorUnknownField) -> Self {
+        ErrorKind::UnknownField(err)
+    }
+}
+
+/// An error for an unknown field, with a possible "did-you-mean" suggestion to get
+/// the user back on the right track.
+#[derive(Debug)]
+// Don't want to publicly commit to ErrorKind supporting equality yet, but
+// not having it makes testing very difficult.
+#[cfg_attr(test, derive(Clone, PartialEq, Eq))]
+struct ErrorUnknownField {
+    name: String,
+    did_you_mean: Option<String>,
+}
+
+impl ErrorUnknownField {
+    pub fn new<I: Into<String>>(name: I, did_you_mean: Option<String>) -> Self {
+        ErrorUnknownField {
+            name: name.into(),
+            did_you_mean,
+        }
+    }
+
+    #[cfg(feature = "diagnostics")]
+    pub fn to_diagnostic(self, span: Option<Span>) -> ::proc_macro::Diagnostic {
+        let base = span.unwrap().unwrap().error(self.top_line());
+        match self.did_you_mean {
+            Some(alt_name) => base.help(format!("did you mean `{}`?", alt_name)),
+            None => base,
+        }
+    }
+
+    #[cfg(feature = "diagnostics")]
+    fn top_line(&self) -> String {
+        format!("Unknown field: `{}`", self.name)
+    }
+}
+
+impl From<String> for ErrorUnknownField {
+    fn from(name: String) -> Self {
+        ErrorUnknownField::new(name, None)
+    }
+}
+
+impl<'a> From<&'a str> for ErrorUnknownField {
+    fn from(name: &'a str) -> Self {
+        ErrorUnknownField::new(name, None)
+    }
+}
+
+impl fmt::Display for ErrorUnknownField {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Unknown field: `{}`", self.name)?;
+
+        if let Some(ref did_you_mean) = self.did_you_mean {
+            write!(f, ". Did you mean `{}`?", did_you_mean)?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(feature = "suggestions")]
+fn did_you_mean<'a, T, I>(field: &str, alternates: I) -> Option<String>
+where
+    T: AsRef<str> + 'a,
+    I: IntoIterator<Item = &'a T>,
+{
+    let mut candidate: Option<(f64, &str)> = None;
+    for pv in alternates {
+        let confidence = ::strsim::jaro_winkler(field, pv.as_ref());
+        if confidence > 0.8 && (candidate.is_none() || (candidate.as_ref().unwrap().0 < confidence))
+        {
+            candidate = Some((confidence, pv.as_ref()));
+        }
+    }
+    match candidate {
+        None => None,
+        Some((_, candidate)) => Some(candidate.into()),
+    }
+}
+
+#[cfg(not(feature = "suggestions"))]
+fn did_you_mean<'a, T, I>(_field: &str, _alternates: I) -> Option<String>
+where
+    T: AsRef<str> + 'a,
+    I: IntoIterator<Item = &'a T>,
+{
+    None
 }
 
 #[cfg(test)]

--- a/core/src/error/kind.rs
+++ b/core/src/error/kind.rs
@@ -1,0 +1,198 @@
+use std::fmt;
+
+use error::Error;
+
+type DeriveInputShape = String;
+type FieldName = String;
+type MetaFormat = String;
+
+#[derive(Debug)]
+// Don't want to publicly commit to ErrorKind supporting equality yet, but
+// not having it makes testing very difficult.
+#[cfg_attr(test, derive(Clone, PartialEq, Eq))]
+pub(in error) enum ErrorKind {
+    /// An arbitrary error message.
+    Custom(String),
+    DuplicateField(FieldName),
+    MissingField(FieldName),
+    UnsupportedShape(DeriveInputShape),
+    UnknownField(ErrorUnknownField),
+    UnexpectedFormat(MetaFormat),
+    UnexpectedType(String),
+    UnknownValue(String),
+    TooFewItems(usize),
+    TooManyItems(usize),
+    /// A set of errors.
+    Multiple(Vec<Error>),
+
+    // TODO make this variant take `!` so it can't exist
+    #[doc(hidden)]
+    __NonExhaustive,
+}
+
+impl ErrorKind {
+    pub fn description(&self) -> &str {
+        use self::ErrorKind::*;
+
+        match *self {
+            Custom(ref s) => s,
+            DuplicateField(_) => "Duplicate field",
+            MissingField(_) => "Missing field",
+            UnknownField(_) => "Unexpected field",
+            UnsupportedShape(_) => "Unsupported shape",
+            UnexpectedFormat(_) => "Unexpected meta-item format",
+            UnexpectedType(_) => "Unexpected literal type",
+            UnknownValue(_) => "Unknown literal value",
+            TooFewItems(_) => "Too few items",
+            TooManyItems(_) => "Too many items",
+            Multiple(_) => "Multiple errors",
+            __NonExhaustive => unreachable!(),
+        }
+    }
+
+    /// Deeply counts the number of errors this item represents.
+    pub fn len(&self) -> usize {
+        if let ErrorKind::Multiple(ref items) = *self {
+            items.iter().map(Error::len).sum()
+        } else {
+            1
+        }
+    }
+}
+
+impl fmt::Display for ErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use self::ErrorKind::*;
+
+        match *self {
+            Custom(ref s) => s.fmt(f),
+            DuplicateField(ref field) => write!(f, "Duplicate field `{}`", field),
+            MissingField(ref field) => write!(f, "Missing field `{}`", field),
+            UnknownField(ref field) => field.fmt(f),
+            UnsupportedShape(ref shape) => write!(f, "Unsupported shape `{}`", shape),
+            UnexpectedFormat(ref format) => write!(f, "Unexpected meta-item format `{}`", format),
+            UnexpectedType(ref ty) => write!(f, "Unexpected literal type `{}`", ty),
+            UnknownValue(ref val) => write!(f, "Unknown literal value `{}`", val),
+            TooFewItems(ref min) => write!(f, "Too few items: Expected at least {}", min),
+            TooManyItems(ref max) => write!(f, "Too many items: Expected no more than {}", max),
+            Multiple(ref items) if items.len() == 1 => items[0].fmt(f),
+            Multiple(ref items) => {
+                write!(f, "Multiple errors: (")?;
+                let mut first = true;
+                for item in items {
+                    if !first {
+                        write!(f, ", ")?;
+                    } else {
+                        first = false;
+                    }
+
+                    item.fmt(f)?;
+                }
+
+                write!(f, ")")
+            }
+            __NonExhaustive => unreachable!(),
+        }
+    }
+}
+
+impl From<ErrorUnknownField> for ErrorKind {
+    fn from(err: ErrorUnknownField) -> Self {
+        ErrorKind::UnknownField(err)
+    }
+}
+
+/// An error for an unknown field, with a possible "did-you-mean" suggestion to get
+/// the user back on the right track.
+#[derive(Debug)]
+// Don't want to publicly commit to ErrorKind supporting equality yet, but
+// not having it makes testing very difficult.
+#[cfg_attr(test, derive(Clone, PartialEq, Eq))]
+pub(in error) struct ErrorUnknownField {
+    name: String,
+    did_you_mean: Option<String>,
+}
+
+impl ErrorUnknownField {
+    pub fn new<I: Into<String>>(name: I, did_you_mean: Option<String>) -> Self {
+        ErrorUnknownField {
+            name: name.into(),
+            did_you_mean,
+        }
+    }
+
+    pub fn with_alts<'a, T, I>(field: &str, alternates: I) -> Self
+    where
+        T: AsRef<str> + 'a,
+        I: IntoIterator<Item = &'a T>,
+    {
+        ErrorUnknownField::new(field, did_you_mean(field, alternates))
+    }
+
+    #[cfg(feature = "diagnostics")]
+    pub fn to_diagnostic(self, span: Option<Span>) -> ::proc_macro::Diagnostic {
+        let base = span.unwrap().unwrap().error(self.top_line());
+        match self.did_you_mean {
+            Some(alt_name) => base.help(format!("did you mean `{}`?", alt_name)),
+            None => base,
+        }
+    }
+
+    #[cfg(feature = "diagnostics")]
+    fn top_line(&self) -> String {
+        format!("Unknown field: `{}`", self.name)
+    }
+}
+
+impl From<String> for ErrorUnknownField {
+    fn from(name: String) -> Self {
+        ErrorUnknownField::new(name, None)
+    }
+}
+
+impl<'a> From<&'a str> for ErrorUnknownField {
+    fn from(name: &'a str) -> Self {
+        ErrorUnknownField::new(name, None)
+    }
+}
+
+impl fmt::Display for ErrorUnknownField {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Unknown field: `{}`", self.name)?;
+
+        if let Some(ref did_you_mean) = self.did_you_mean {
+            write!(f, ". Did you mean `{}`?", did_you_mean)?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(feature = "suggestions")]
+fn did_you_mean<'a, T, I>(field: &str, alternates: I) -> Option<String>
+where
+    T: AsRef<str> + 'a,
+    I: IntoIterator<Item = &'a T>,
+{
+    let mut candidate: Option<(f64, &str)> = None;
+    for pv in alternates {
+        let confidence = ::strsim::jaro_winkler(field, pv.as_ref());
+        if confidence > 0.8 && (candidate.is_none() || (candidate.as_ref().unwrap().0 < confidence))
+        {
+            candidate = Some((confidence, pv.as_ref()));
+        }
+    }
+    match candidate {
+        None => None,
+        Some((_, candidate)) => Some(candidate.into()),
+    }
+}
+
+#[cfg(not(feature = "suggestions"))]
+fn did_you_mean<'a, T, I>(_field: &str, _alternates: I) -> Option<String>
+where
+    T: AsRef<str> + 'a,
+    I: IntoIterator<Item = &'a T>,
+{
+    None
+}

--- a/core/src/error/mod.rs
+++ b/core/src/error/mod.rs
@@ -1,4 +1,10 @@
-//! Types for working with darling errors and results.
+//! The `darling::Error` type and its internals.
+//!
+//! Error handling is one of the core values of `darling`; creating great errors is hard and
+//! never the reason that a proc-macro author started writing their crate. As a result, the
+//! `Error` type in `darling` tries to make adding span information, suggestions, and other
+//! help content easy when manually implementing `darling` traits, and automatic when deriving
+//! them.
 
 use proc_macro2::{Span, TokenStream};
 use std::error::Error as StdError;
@@ -8,6 +14,10 @@ use std::string::ToString;
 use std::vec;
 use syn::spanned::Spanned;
 use syn::{Lit, LitStr};
+
+mod kind;
+
+use self::kind::{ErrorKind, ErrorUnknownField};
 
 /// An alias of `Result` specific to attribute parsing.
 pub type Result<T> = ::std::result::Result<T, Error>;
@@ -27,7 +37,7 @@ pub struct Error {
 
 /// Error creation functions
 impl Error {
-    fn new(kind: ErrorKind) -> Self {
+    pub(in error) fn new(kind: ErrorKind) -> Self {
         Error {
             kind,
             locations: Vec::new(),
@@ -64,11 +74,7 @@ impl Error {
         T: AsRef<str> + 'a,
         I: IntoIterator<Item = &'a T>,
     {
-        let did_you_mean = did_you_mean(field, alternates);
-        Error::new(ErrorKind::UnknownField(ErrorUnknownField::new(
-            field,
-            did_you_mean,
-        )))
+        Error::new(ErrorUnknownField::with_alts(field, alternates).into())
     }
 
     /// Creates a new error for a struct or variant that does not adhere to the supported shape.
@@ -310,7 +316,7 @@ impl Error {
             kind => match self.span {
                 Some(span) => span.unwrap().error(kind.to_string()),
                 None => Diagnostic::new(Level::Error, self.to_string()),
-            }
+            },
         }
     }
 
@@ -431,193 +437,6 @@ impl Iterator for IntoIter {
     fn next(&mut self) -> Option<Error> {
         self.inner.next()
     }
-}
-
-type DeriveInputShape = String;
-type FieldName = String;
-type MetaFormat = String;
-
-#[derive(Debug)]
-// Don't want to publicly commit to ErrorKind supporting equality yet, but
-// not having it makes testing very difficult.
-#[cfg_attr(test, derive(Clone, PartialEq, Eq))]
-enum ErrorKind {
-    /// An arbitrary error message.
-    Custom(String),
-    DuplicateField(FieldName),
-    MissingField(FieldName),
-    UnsupportedShape(DeriveInputShape),
-    UnknownField(ErrorUnknownField),
-    UnexpectedFormat(MetaFormat),
-    UnexpectedType(String),
-    UnknownValue(String),
-    TooFewItems(usize),
-    TooManyItems(usize),
-    /// A set of errors.
-    Multiple(Vec<Error>),
-
-    // TODO make this variant take `!` so it can't exist
-    #[doc(hidden)]
-    __NonExhaustive,
-}
-
-impl ErrorKind {
-    pub fn description(&self) -> &str {
-        use self::ErrorKind::*;
-
-        match *self {
-            Custom(ref s) => s,
-            DuplicateField(_) => "Duplicate field",
-            MissingField(_) => "Missing field",
-            UnknownField(_) => "Unexpected field",
-            UnsupportedShape(_) => "Unsupported shape",
-            UnexpectedFormat(_) => "Unexpected meta-item format",
-            UnexpectedType(_) => "Unexpected literal type",
-            UnknownValue(_) => "Unknown literal value",
-            TooFewItems(_) => "Too few items",
-            TooManyItems(_) => "Too many items",
-            Multiple(_) => "Multiple errors",
-            __NonExhaustive => unreachable!(),
-        }
-    }
-
-    /// Deeply counts the number of errors this item represents.
-    pub fn len(&self) -> usize {
-        if let ErrorKind::Multiple(ref items) = *self {
-            items.iter().map(Error::len).sum()
-        } else {
-            1
-        }
-    }
-}
-
-impl fmt::Display for ErrorKind {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use self::ErrorKind::*;
-
-        match *self {
-            Custom(ref s) => s.fmt(f),
-            DuplicateField(ref field) => write!(f, "Duplicate field `{}`", field),
-            MissingField(ref field) => write!(f, "Missing field `{}`", field),
-            UnknownField(ref field) => field.fmt(f),
-            UnsupportedShape(ref shape) => write!(f, "Unsupported shape `{}`", shape),
-            UnexpectedFormat(ref format) => write!(f, "Unexpected meta-item format `{}`", format),
-            UnexpectedType(ref ty) => write!(f, "Unexpected literal type `{}`", ty),
-            UnknownValue(ref val) => write!(f, "Unknown literal value `{}`", val),
-            TooFewItems(ref min) => write!(f, "Too few items: Expected at least {}", min),
-            TooManyItems(ref max) => write!(f, "Too many items: Expected no more than {}", max),
-            Multiple(ref items) if items.len() == 1 => items[0].fmt(f),
-            Multiple(ref items) => {
-                write!(f, "Multiple errors: (")?;
-                let mut first = true;
-                for item in items {
-                    if !first {
-                        write!(f, ", ")?;
-                    } else {
-                        first = false;
-                    }
-
-                    item.fmt(f)?;
-                }
-
-                write!(f, ")")
-            }
-            __NonExhaustive => unreachable!(),
-        }
-    }
-}
-
-impl From<ErrorUnknownField> for ErrorKind {
-    fn from(err: ErrorUnknownField) -> Self {
-        ErrorKind::UnknownField(err)
-    }
-}
-
-/// An error for an unknown field, with a possible "did-you-mean" suggestion to get
-/// the user back on the right track.
-#[derive(Debug)]
-// Don't want to publicly commit to ErrorKind supporting equality yet, but
-// not having it makes testing very difficult.
-#[cfg_attr(test, derive(Clone, PartialEq, Eq))]
-struct ErrorUnknownField {
-    name: String,
-    did_you_mean: Option<String>,
-}
-
-impl ErrorUnknownField {
-    pub fn new<I: Into<String>>(name: I, did_you_mean: Option<String>) -> Self {
-        ErrorUnknownField {
-            name: name.into(),
-            did_you_mean,
-        }
-    }
-
-    #[cfg(feature = "diagnostics")]
-    pub fn to_diagnostic(self, span: Option<Span>) -> ::proc_macro::Diagnostic {
-        let base = span.unwrap().unwrap().error(self.top_line());
-        match self.did_you_mean {
-            Some(alt_name) => base.help(format!("did you mean `{}`?", alt_name)),
-            None => base,
-        }
-    }
-
-    #[cfg(feature = "diagnostics")]
-    fn top_line(&self) -> String {
-        format!("Unknown field: `{}`", self.name)
-    }
-}
-
-impl From<String> for ErrorUnknownField {
-    fn from(name: String) -> Self {
-        ErrorUnknownField::new(name, None)
-    }
-}
-
-impl<'a> From<&'a str> for ErrorUnknownField {
-    fn from(name: &'a str) -> Self {
-        ErrorUnknownField::new(name, None)
-    }
-}
-
-impl fmt::Display for ErrorUnknownField {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Unknown field: `{}`", self.name)?;
-
-        if let Some(ref did_you_mean) = self.did_you_mean {
-            write!(f, ". Did you mean `{}`?", did_you_mean)?;
-        }
-
-        Ok(())
-    }
-}
-
-#[cfg(feature = "suggestions")]
-fn did_you_mean<'a, T, I>(field: &str, alternates: I) -> Option<String>
-where
-    T: AsRef<str> + 'a,
-    I: IntoIterator<Item = &'a T>,
-{
-    let mut candidate: Option<(f64, &str)> = None;
-    for pv in alternates {
-        let confidence = ::strsim::jaro_winkler(field, pv.as_ref());
-        if confidence > 0.8 && (candidate.is_none() || (candidate.as_ref().unwrap().0 < confidence))
-        {
-            candidate = Some((confidence, pv.as_ref()));
-        }
-    }
-    match candidate {
-        None => None,
-        Some((_, candidate)) => Some(candidate.into()),
-    }
-}
-
-#[cfg(not(feature = "suggestions"))]
-fn did_you_mean<'a, T, I>(_field: &str, _alternates: I) -> Option<String>
-where
-    T: AsRef<str> + 'a,
-    I: IntoIterator<Item = &'a T>,
-{
-    None
 }
 
 #[cfg(test)]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -10,6 +10,8 @@ extern crate ident_case;
 #[cfg(feature = "diagnostics")]
 extern crate proc_macro;
 extern crate proc_macro2;
+#[cfg(feature = "suggestions")]
+extern crate strsim;
 
 #[macro_use]
 mod macros_private;

--- a/core/src/usage/type_params.rs
+++ b/core/src/usage/type_params.rs
@@ -246,7 +246,7 @@ impl UsesTypeParams for syn::TypeParamBound {
 #[cfg(test)]
 mod tests {
     use proc_macro2::Span;
-    use syn::{self, DeriveInput, Ident};
+    use syn::{DeriveInput, Ident};
 
     use super::UsesTypeParams;
     use usage::IdentSet;

--- a/tests/suggestions.rs
+++ b/tests/suggestions.rs
@@ -1,0 +1,34 @@
+#![cfg(feature = "suggestions")]
+
+#[macro_use]
+extern crate darling;
+#[macro_use]
+extern crate syn;
+#[macro_use]
+extern crate quote;
+
+use darling::FromDeriveInput;
+
+#[derive(Debug, FromDeriveInput)]
+#[darling(attributes(suggest))]
+struct Lorem {
+    ipsum: String,
+    dolor: Dolor,
+}
+
+#[derive(Debug, FromMeta)]
+struct Dolor {
+    sit: bool,
+}
+
+#[test]
+fn suggest_dolor() {
+    let input: syn::DeriveInput = parse_quote! {
+        #[suggest(ipsum = "Hello", dolorr(sit))]
+        pub struct Foo;
+    };
+
+    let result = Lorem::from_derive_input(&input).unwrap_err();
+    assert_eq!(2, result.len());
+    assert!(format!("{}", result).contains("Did you mean"));
+}


### PR DESCRIPTION
This adds a "did you mean" message to unknown field errors emitted from generated impls. The feature will be optional in 0.8.x, but enabled by default in 0.9.0