### PR TITLE
V0.9 staging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: rust
 
 rust:
-  - 1.18.0
+  - 1.33.0
   - stable
   - beta
   - nightly
@@ -14,5 +14,7 @@ env:
 # Test with and without the suggestion feature enabled
 # See https://github.com/servo/rust-smallvec/blob/master/.travis.yml for guide
 script: |
-  cargo test --verbose &&
-  ([ $TRAVIS_RUST_VERSION = 1.18.0 ] || cargo test --verbose --features suggestions)
+  cargo test --verbose
+
+# To add tests that exclude older rust versions, use the following format
+# ([ $TRAVIS_RUST_VERSION = 1.18.0 ] || cargo test --verbose --features suggestions)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
 ## v0.9.0
+- Bump minimum rustc version to 1.33.0 [#49](https://github.com/TedDriggs/darling/issues/49)
 - Enable "did you mean" suggestions by default
+- Make `darling_core::{codegen, options}` private [#58](https://github.com/TedDriggs/darling/issues/58)
+- Fix `Override::as_mut`: [#66](https://github.com/TedDriggs/darling/issues/66)
 
 ## v0.8.6 (March 18, 2019)
 - Added "did you mean" suggestions for unknown fields behind the `suggestions` flag [#60](https://github.com/TedDriggs/issues/60)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.9.0
+- Enable "did you mean" suggestions by default
+
 ## v0.8.6 (March 18, 2019)
 - Added "did you mean" suggestions for unknown fields behind the `suggestions` flag [#60](https://github.com/TedDriggs/issues/60)
 - Added `Error::unknown_field_with_alts` to support the suggestion use-case.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ quote = "0.6"
 syn = "0.15.26"
 
 [features]
+default = ["suggestions"]
 diagnostics = ["darling_core/diagnostics"]
 suggestions = ["darling_core/suggestions"]
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ Darling
 # Example
 
 ```rust,ignore
-#[macro_use]
 extern crate darling;
 extern crate syn;
+
+use darling::{FromDeriveInput, FromMeta};
 
 #[derive(Default, FromMeta)]
 #[darling(default)]

--- a/README.md
+++ b/README.md
@@ -101,3 +101,6 @@ Darling's features are built to work well for real-world projects.
 * **Skip fields**: Use `#[darling(skip)]` to mark a field that shouldn't be read from attribute meta-items.
 * **Multiple-occurrence fields**: Use `#[darling(multiple)]` on a `Vec` field to allow that field to appear multiple times in the meta-item. Each occurrence will be pushed into the `Vec`.
 * **Span access**: Use `darling::util::SpannedValue` in a struct to get access to that meta item's source code span. This can be used to emit warnings that point at a specific field from your proc macro. In addition, you can use `darling::Error::write_errors` to automatically get precise error location details in most cases.
+
+# Rust Versions
+v0.8 supports rustc ≥ 1.18.0; v0.9 supports rustc ≥ 1.33.0.

--- a/core/src/ast/data.rs
+++ b/core/src/ast/data.rs
@@ -29,8 +29,8 @@ impl<V, F> Data<V, F> {
         }
     }
 
-    /// Creates a new `Data<&'a V, &'a F>` instance from `Data<V, F>`.
-    pub fn as_ref<'a>(&'a self) -> Data<&'a V, &'a F> {
+    /// Creates a new `Data<&V, &F>` instance from `Data<V, F>`.
+    pub fn as_ref(&self) -> Data<&V, &F> {
         match *self {
             Data::Enum(ref variants) => Data::Enum(variants.iter().collect()),
             Data::Struct(ref data) => Data::Struct(data.as_ref()),

--- a/core/src/ast/generics.rs
+++ b/core/src/ast/generics.rs
@@ -142,7 +142,7 @@ pub struct Generics<P, W = syn::WhereClause> {
 }
 
 impl<P, W> Generics<P, W> {
-    pub fn type_params<'a>(&'a self) -> TypeParams<'a, P> {
+    pub fn type_params(&self) -> TypeParams<'_, P> {
         TypeParams(self.params.iter())
     }
 }

--- a/core/src/codegen/trait_impl.rs
+++ b/core/src/codegen/trait_impl.rs
@@ -34,7 +34,7 @@ impl<'a> TraitImpl<'a> {
         self.type_params_matching(|f| !f.skip, |v| !v.skip)
     }
 
-    fn type_params_matching<'b, F, V>(&'b self, field_filter: F, variant_filter: V) -> IdentSet
+    fn type_params_matching<F, V>(&self, field_filter: F, variant_filter: V) -> IdentSet
     where
         F: Fn(&&Field) -> bool,
         V: Fn(&&Variant) -> bool,

--- a/core/src/codegen/trait_impl.rs
+++ b/core/src/codegen/trait_impl.rs
@@ -27,14 +27,11 @@ impl<'a> TraitImpl<'a> {
             .collect()
     }
 
-    /// Get the type parameters which are used by non-skipped fields.
+    /// Get the type parameters which are used by non-skipped, non-magic fields.
+    /// These type parameters will have a `FromMeta` bound applied to them in emitted
+    /// code.
     pub fn used_type_params(&self) -> IdentSet {
         self.type_params_matching(|f| !f.skip, |v| !v.skip)
-    }
-
-    /// Get the type parameters which are used by skipped fields.
-    pub fn skipped_type_params(&self) -> IdentSet {
-        self.type_params_matching(|f| f.skip, |v| v.skip)
     }
 
     fn type_params_matching<'b, F, V>(&'b self, field_filter: F, variant_filter: V) -> IdentSet

--- a/core/src/error/mod.rs
+++ b/core/src/error/mod.rs
@@ -177,6 +177,7 @@ impl Error {
 }
 
 /// Error instance methods
+#[allow(clippy::len_without_is_empty)]
 impl Error {
     /// Check if this error is associated with a span in the token stream.
     pub fn has_span(&self) -> bool {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -19,7 +19,7 @@ mod macros_private;
 mod macros_public;
 
 pub mod ast;
-pub mod codegen;
+pub(crate) mod codegen;
 pub mod derive;
 pub mod error;
 mod from_derive_input;
@@ -29,7 +29,7 @@ mod from_generics;
 mod from_meta;
 mod from_type_param;
 mod from_variant;
-pub mod options;
+pub(crate) mod options;
 pub mod usage;
 pub mod util;
 

--- a/core/src/options/core.rs
+++ b/core/src/options/core.rs
@@ -60,7 +60,7 @@ impl Core {
         }
     }
 
-    fn as_codegen_default<'a>(&'a self) -> Option<codegen::DefaultExpression<'a>> {
+    fn as_codegen_default(&self) -> Option<codegen::DefaultExpression<'_>> {
         self.default.as_ref().map(|expr| match *expr {
             DefaultExpression::Explicit(ref path) => codegen::DefaultExpression::Explicit(path),
             DefaultExpression::Inherit | DefaultExpression::Trait => {

--- a/core/src/options/input_field.rs
+++ b/core/src/options/input_field.rs
@@ -23,7 +23,7 @@ pub struct InputField {
 
 impl InputField {
     /// Generate a view into this field that can be used for code generation.
-    pub fn as_codegen_field<'a>(&'a self) -> codegen::Field<'a> {
+    pub fn as_codegen_field(&self) -> codegen::Field<'_> {
         codegen::Field {
             ident: &self.ident,
             name_in_attr: self
@@ -44,7 +44,7 @@ impl InputField {
 
     /// Generate a codegen::DefaultExpression for this field. This requires the field name
     /// in the `Inherit` case.
-    fn as_codegen_default<'a>(&'a self) -> Option<codegen::DefaultExpression<'a>> {
+    fn as_codegen_default(&'_ self) -> Option<codegen::DefaultExpression<'_>> {
         self.default.as_ref().map(|expr| match *expr {
             DefaultExpression::Explicit(ref path) => codegen::DefaultExpression::Explicit(path),
             DefaultExpression::Inherit => codegen::DefaultExpression::Inherit(&self.ident),

--- a/core/src/options/shape.rs
+++ b/core/src/options/shape.rs
@@ -134,7 +134,7 @@ impl DataShape {
     }
 
     fn set_word(&mut self, word: &str) -> Result<()> {
-        match word.trim_left_matches(self.prefix) {
+        match word.trim_start_matches(self.prefix) {
             "newtype" => {
                 self.newtype = true;
                 Ok(())
@@ -188,7 +188,7 @@ impl ToTokens for DataShape {
         let body = if self.any {
             quote!(::darling::export::Ok(()))
         } else if self.supports_none() {
-            let ty = self.prefix.trim_right_matches('_');
+            let ty = self.prefix.trim_end_matches('_');
             quote!(::darling::export::Err(::darling::Error::unsupported_shape(#ty)))
         } else {
             let unit = match_arm("unit", self.unit);

--- a/core/src/options/shape.rs
+++ b/core/src/options/shape.rs
@@ -1,9 +1,24 @@
+//! Types for "shape" validation. This allows types deriving `FromDeriveInput` etc. to declare
+//! that they only work on - for example - structs with named fields, or newtype enum variants.
+
 use proc_macro2::TokenStream;
 use quote::{ToTokens, TokenStreamExt};
 use syn::{Meta, NestedMeta};
 
 use {Error, FromMeta, Result};
 
+/// Receiver struct for shape validation. Shape validation allows a deriving type
+/// to declare that it only accepts - for example - named structs, or newtype enum
+/// variants.
+///
+/// # Usage
+/// Because `Shape` implements `FromMeta`, the name of the field where it appears is
+/// controlled by the struct that declares `Shape` as a member. That field name is
+/// shown as `ignore` below.
+///
+/// ```rust,ignore
+/// #[ignore(any, struct_named, enum_newtype)]
+/// ```
 #[derive(Debug, Clone)]
 pub struct Shape {
     enum_values: DataShape,
@@ -97,6 +112,8 @@ impl ToTokens for Shape {
     }
 }
 
+/// Receiver for shape information within a struct or enum context. See `Shape` for more information
+/// on valid uses of shape validation.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct DataShape {
     /// The kind of shape being described. This can be `struct_` or `enum_`.

--- a/core/src/options/shape.rs
+++ b/core/src/options/shape.rs
@@ -26,15 +26,6 @@ pub struct Shape {
     any: bool,
 }
 
-impl Shape {
-    pub fn all() -> Self {
-        Shape {
-            any: true,
-            ..Default::default()
-        }
-    }
-}
-
 impl Default for Shape {
     fn default() -> Self {
         Shape {

--- a/core/src/util/over_ride.rs
+++ b/core/src/util/over_ride.rs
@@ -59,7 +59,7 @@ impl<T> Override<T> {
     /// Converts from `Override<T>` to `Override<&mut T>`.
     ///
     /// Produces a new `Override`, containing a mutable reference into the original.
-    pub fn as_mut(&mut self) -> Override<&T> {
+    pub fn as_mut(&mut self) -> Override<&mut T> {
         match *self {
             Inherit => Inherit,
             Explicit(ref mut val) => Explicit(val),

--- a/core/src/util/over_ride.rs
+++ b/core/src/util/over_ride.rs
@@ -49,7 +49,7 @@ impl<T> Override<T> {
     /// Converts from `Override<T>` to `Override<&T>`.
     ///
     /// Produces a new `Override`, containing a reference into the original, leaving the original in place.
-    pub fn as_ref<'a>(&'a self) -> Override<&'a T> {
+    pub fn as_ref(&self) -> Override<&T> {
         match *self {
             Inherit => Inherit,
             Explicit(ref val) => Explicit(val),
@@ -59,7 +59,7 @@ impl<T> Override<T> {
     /// Converts from `Override<T>` to `Override<&mut T>`.
     ///
     /// Produces a new `Override`, containing a mutable reference into the original.
-    pub fn as_mut<'a>(&'a mut self) -> Override<&'a T> {
+    pub fn as_mut(&mut self) -> Override<&T> {
         match *self {
             Inherit => Inherit,
             Explicit(ref mut val) => Explicit(val),

--- a/examples/fallible_read.rs
+++ b/examples/fallible_read.rs
@@ -4,7 +4,6 @@
 //! 1. Using `darling::Result` as a carrier to preserve the error for later display
 //! 1. Using `Result<T, syn::Meta>` to attempt a recovery in imperative code
 //! 1. Using the `map` darling meta-item to post-process the receiver before returning.
-#[macro_use]
 extern crate darling;
 
 extern crate syn;

--- a/tests/defaults.rs
+++ b/tests/defaults.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 extern crate darling;
 #[macro_use]
 extern crate quote;

--- a/tests/from_type_param.rs
+++ b/tests/from_type_param.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 extern crate darling;
 #[macro_use]
 extern crate syn;

--- a/tests/from_type_param_default.rs
+++ b/tests/from_type_param_default.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 extern crate darling;
 #[macro_use]
 extern crate syn;

--- a/tests/split_declaration.rs
+++ b/tests/split_declaration.rs
@@ -1,7 +1,6 @@
 //! When input is split across multiple attributes on one element,
 //! darling should collapse that into one struct.
 
-#[macro_use]
 extern crate darling;
 #[macro_use]
 extern crate syn;

--- a/tests/supports.rs
+++ b/tests/supports.rs
@@ -28,7 +28,7 @@ pub struct StructContainer {
 }
 
 mod source {
-    use syn::{self, DeriveInput};
+    use syn::DeriveInput;
 
     pub fn newtype_enum() -> DeriveInput {
         parse_quote!{


### PR DESCRIPTION
Prepare for v0.9

- Bump rustc to 1.33.0: #49 
- Make `darling_core::{codegen, options}` private: #58 
- Fix `Override::as_mut`: #66 
- Add Clippy attributes: Relates to #46 
- Enable suggestions by default