### PR TITLE
Fix compilation error in darling_core tests

### DIFF
--- a/core/src/from_meta.rs
+++ b/core/src/from_meta.rs
@@ -387,7 +387,7 @@ mod tests {
     /// parse a string as a syn::Meta instance.
     fn pm(tokens: TokenStream) -> ::std::result::Result<syn::Meta, String> {
         let attribute: syn::Attribute = parse_quote!(#[#tokens]);
-        attribute.parse_meta().ok_or("Unable to parse".into())
+        attribute.parse_meta().map_err(|_| "Unable to parse".into())
     }
 
     fn fm<T: FromMeta>(tokens: TokenStream) -> T {

--- a/core/src/util/path_list.rs
+++ b/core/src/util/path_list.rs
@@ -70,7 +70,7 @@ mod tests {
     /// parse a string as a syn::Meta instance.
     fn pm(tokens: TokenStream) -> ::std::result::Result<Meta, String> {
         let attribute: Attribute = parse_quote!(#[#tokens]);
-        attribute.parse_meta().ok_or("Unable to parse".into())
+        attribute.parse_meta().map_err(|_| "Unable to parse".into())
     }
 
     fn fm<T: FromMeta>(tokens: TokenStream) -> T {
@@ -82,7 +82,7 @@ mod tests {
     fn succeeds() {
         let paths = fm::<PathList>(quote!(ignore(Debug, Clone, Eq)));
         assert_eq!(
-            idents.to_strings(),
+            paths.to_strings(),
             vec![
                 String::from("Debug"),
                 String::from("Clone"),


### PR DESCRIPTION
This patch fixes three compilation errors in the tests for darling_core
by fixing a wrong variable name and replace two calls to Result::ok_err
with Result::map_err.  Fixes #80.