### PR TITLE
syn: bump minimum to 1.0.1

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,6 +17,6 @@ suggestions = ["strsim"]
 ident_case = "1.0.0"
 proc-macro2 = "1"
 quote = "1"
-syn = { version = "1", features = ["full", "extra-traits"] }
+syn = { version = "1.0.1", features = ["full", "extra-traits"] }
 fnv = "1.0.6"
 strsim = { version = "0.9.0", optional = true }


### PR DESCRIPTION
This version introduces the `base10_parse` symbol used within the core
crate.