### PR TITLE
core/Cargo: bump strsim dependency

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -19,4 +19,4 @@ proc-macro2 = "1"
 quote = "1"
 syn = { version = "1.0.1", features = ["full", "extra-traits"] }
 fnv = "1.0.6"
-strsim = { version = "0.9.0", optional = true }
+strsim = { version = "0.10.0", optional = true }


### PR DESCRIPTION
0.10 only added new features, no code changes are necessary.