### PR TITLE
impl From<syn::Error> for Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   Any crates using `darling` that relied on those attributes being silently ignored could see new errors reported in their dependent crates. [#113](https://github.com/TedDriggs/darling/pull/113)
 - Impl `syn::spanned::Spanned` for `darling::util::SpannedValue` [#113](https://github.com/TedDriggs/darling/pull/113)
 - Add `darling::util::parse_attribute_to_meta_list` to provide useful errors during attribute parsing [#113](https://github.com/TedDriggs/darling/pull/113)
+- Add `impl From<syn::Error> for Error` to losslessly propagate `syn` errors [#116](https://github.com/TedDriggs/darling/pull/116)
 
 ## v0.11.0 (December 14, 2020)
 - Bump minor version due to unexpected breaking change [#107](https://github.com/TedDriggs/darling/issues/107)

--- a/core/src/error/mod.rs
+++ b/core/src/error/mod.rs
@@ -399,6 +399,19 @@ impl fmt::Display for Error {
     }
 }
 
+impl From<syn::Error> for Error {
+    fn from(e: syn::Error) -> Self {
+        // This impl assumes there is nothing but the message and span that needs to be preserved
+        // from the passed-in error. If this changes at some point, a new ErrorKind should be made
+        // to hold the syn::Error, and this impl should preserve it unmodified while setting its own
+        // span to be a copy of the passed-in error.
+        Self {
+            span: Some(e.span()),
+            ..Self::custom(e)
+        }
+    }
+}
+
 // Don't want to publicly commit to Error supporting equality yet, but
 // not having it makes testing very difficult. Note that spans are not
 // considered for equality since that would break testing in most cases.


### PR DESCRIPTION
`syn` provides useful functions for low-level AST parsing that go beyond
what `darling` attempts to support natively. In these cases, a caller
may want to propagate a `syn::Error` up through a function that returns
a `darling::Result`.

This new impl guarantees lossless handling, emitting the same compiler
error is emitted as if the `syn::Error::to_compile_error` had been
called directly.