### PR TITLE
Fix FromMeta for chars

### DIFF
--- a/core/src/from_meta.rs
+++ b/core/src/from_meta.rs
@@ -163,8 +163,12 @@ impl FromMeta for char {
     }
 
     fn from_string(s: &str) -> Result<Self> {
-        if s.chars().count() == 1 {
-            Ok(s.chars().next().unwrap())
+        let mut chars = s.chars();
+        let char1 = chars.next();
+        let char2 = chars.next();
+
+        if let (Some(char), None) = (char1, char2) {
+            Ok(char)
         } else {
             Err(Error::unexpected_type("string"))
         }

--- a/core/src/from_meta.rs
+++ b/core/src/from_meta.rs
@@ -617,8 +617,9 @@ mod tests {
     #[test]
     fn char_succeeds() {
         // char literal
-
         assert_eq!(fm::<char>(quote!(ignore = '😬')), '😬');
+
+        // string literal
         assert_eq!(fm::<char>(quote!(ignore = "😬")), '😬');
     }
 


### PR DESCRIPTION
Hello

Yesterday I spent all evening figuring out why my proc macro cannot recognize char attributes after I redefined FromMeta::from_char for my newtype. Here is the fix for the issue. I also add FromMeta impl for char as I don't see any reason why darling doesn't support chars out of the box. 

Nice lib, btw))