### PR TITLE
Update to 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,9 @@ darling_core = { version = "=0.12.4", path = "core" }
 darling_macro = { version = "=0.12.4", path = "macro" }
 
 [dev-dependencies]
-proc-macro2 = "1"
-quote = "1"
-syn = "1"
+proc-macro2 = "1.0.26"
+quote = "1.0.9"
+syn = "1.0.69"
 
 [features]
 default = ["suggestions"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ implementing custom derives.
 """
 license = "MIT"
 readme = "README.md"
+edition = "2018"
 exclude = ["/.travis.yml", "/publish.sh", "/.github/**"]
 
 [badges]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,9 +15,9 @@ diagnostics = []
 suggestions = ["strsim"]
 
 [dependencies]
-ident_case = "1.0.0"
-proc-macro2 = "1"
-quote = "1"
-syn = { version = "1.0.1", features = ["full", "extra-traits"] }
-fnv = "1.0.6"
+ident_case = "1.0.1"
+proc-macro2 = "1.0.26"
+quote = "1.0.9"
+syn = { version = "1.0.69", features = ["full", "extra-traits"] }
+fnv = "1.0.7"
 strsim = { version = "0.10.0", optional = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -8,6 +8,7 @@ Helper crate for proc-macro library for reading attributes into structs when
 implementing custom derives. Use https://crates.io/crates/darling in your code.
 """
 license = "MIT"
+edition = "2018"
 
 [features]
 diagnostics = []

--- a/core/src/ast/data.rs
+++ b/core/src/ast/data.rs
@@ -4,10 +4,10 @@ use proc_macro2::{Span, TokenStream};
 use quote::ToTokens;
 use syn::spanned::Spanned;
 
-use usage::{
+use crate::usage::{
     self, IdentRefSet, IdentSet, LifetimeRefSet, LifetimeSet, UsesLifetimes, UsesTypeParams,
 };
-use {Error, FromField, FromVariant, Result};
+use crate::{Error, FromField, FromVariant, Result};
 
 /// A struct or enum body.
 ///

--- a/core/src/ast/generics.rs
+++ b/core/src/ast/generics.rs
@@ -3,9 +3,7 @@
 use std::iter::Iterator;
 use std::slice::Iter;
 
-use syn;
-
-use {FromGenericParam, FromGenerics, FromTypeParam, Result};
+use crate::{FromGenericParam, FromGenerics, FromTypeParam, Result};
 
 /// Extension trait for `GenericParam` to support getting values by variant.
 ///
@@ -179,10 +177,8 @@ impl<'a, P: GenericParamExt> Iterator for TypeParams<'a, P> {
 
 #[cfg(test)]
 mod tests {
-    use syn;
-
     use super::{GenericParam, Generics};
-    use FromGenerics;
+    use crate::FromGenerics;
 
     #[test]
     fn generics() {

--- a/core/src/codegen/attr_extractor.rs
+++ b/core/src/codegen/attr_extractor.rs
@@ -1,7 +1,7 @@
 use proc_macro2::TokenStream;
 
-use options::ForwardAttrs;
-use util::PathList;
+use crate::options::ForwardAttrs;
+use crate::util::PathList;
 
 /// Infrastructure for generating an attribute extractor.
 pub trait ExtractAttribute {

--- a/core/src/codegen/field.rs
+++ b/core/src/codegen/field.rs
@@ -4,8 +4,8 @@ use proc_macro2::TokenStream;
 use quote::{ToTokens, TokenStreamExt};
 use syn::{Ident, Path, Type};
 
-use codegen::{DefaultExpression, PostfixTransform};
-use usage::{self, IdentRefSet, IdentSet, UsesTypeParams};
+use crate::codegen::{DefaultExpression, PostfixTransform};
+use crate::usage::{self, IdentRefSet, IdentSet, UsesTypeParams};
 
 /// Properties needed to generate code for a field in all the contexts
 /// where one may appear.

--- a/core/src/codegen/from_derive_impl.rs
+++ b/core/src/codegen/from_derive_impl.rs
@@ -1,11 +1,13 @@
 use proc_macro2::TokenStream;
 use quote::ToTokens;
-use syn::{self, Ident};
+use syn::Ident;
 
-use ast::Data;
-use codegen::{ExtractAttribute, OuterFromImpl, TraitImpl};
-use options::{ForwardAttrs, Shape};
-use util::PathList;
+use crate::{
+    ast::Data,
+    codegen::{ExtractAttribute, OuterFromImpl, TraitImpl},
+    options::{ForwardAttrs, Shape},
+    util::PathList,
+};
 
 pub struct FromDeriveInputImpl<'a> {
     pub ident: Option<&'a Ident>,

--- a/core/src/codegen/from_field.rs
+++ b/core/src/codegen/from_field.rs
@@ -1,10 +1,12 @@
 use proc_macro2::TokenStream;
 use quote::ToTokens;
-use syn::{self, Ident};
+use syn::Ident;
 
-use codegen::{ExtractAttribute, OuterFromImpl, TraitImpl};
-use options::ForwardAttrs;
-use util::PathList;
+use crate::{
+    codegen::{ExtractAttribute, OuterFromImpl, TraitImpl},
+    options::ForwardAttrs,
+    util::PathList,
+};
 
 /// `impl FromField` generator. This is used for parsing an individual
 /// field and its attributes.

--- a/core/src/codegen/from_meta_impl.rs
+++ b/core/src/codegen/from_meta_impl.rs
@@ -1,9 +1,8 @@
 use proc_macro2::TokenStream;
 use quote::ToTokens;
-use syn;
 
-use ast::{Data, Fields, Style};
-use codegen::{Field, OuterFromImpl, TraitImpl, Variant};
+use crate::ast::{Data, Fields, Style};
+use crate::codegen::{Field, OuterFromImpl, TraitImpl, Variant};
 
 pub struct FromMetaImpl<'a> {
     pub base: TraitImpl<'a>,

--- a/core/src/codegen/from_type_param.rs
+++ b/core/src/codegen/from_type_param.rs
@@ -1,10 +1,10 @@
 use proc_macro2::TokenStream;
 use quote::ToTokens;
-use syn::{self, Ident};
+use syn::Ident;
 
-use codegen::{ExtractAttribute, OuterFromImpl, TraitImpl};
-use options::ForwardAttrs;
-use util::PathList;
+use crate::codegen::{ExtractAttribute, OuterFromImpl, TraitImpl};
+use crate::options::ForwardAttrs;
+use crate::util::PathList;
 
 pub struct FromTypeParamImpl<'a> {
     pub base: TraitImpl<'a>,

--- a/core/src/codegen/from_variant_impl.rs
+++ b/core/src/codegen/from_variant_impl.rs
@@ -1,10 +1,10 @@
 use proc_macro2::TokenStream;
 use quote::ToTokens;
-use syn::{self, Ident};
+use syn::Ident;
 
-use codegen::{ExtractAttribute, OuterFromImpl, TraitImpl};
-use options::{DataShape, ForwardAttrs};
-use util::PathList;
+use crate::codegen::{ExtractAttribute, OuterFromImpl, TraitImpl};
+use crate::options::{DataShape, ForwardAttrs};
+use crate::util::PathList;
 
 pub struct FromVariantImpl<'a> {
     pub base: TraitImpl<'a>,

--- a/core/src/codegen/mod.rs
+++ b/core/src/codegen/mod.rs
@@ -13,7 +13,7 @@ mod trait_impl;
 mod variant;
 mod variant_data;
 
-pub(in codegen) use self::attr_extractor::ExtractAttribute;
+pub(in crate::codegen) use self::attr_extractor::ExtractAttribute;
 pub use self::default_expr::DefaultExpression;
 pub use self::field::Field;
 pub use self::from_derive_impl::FromDeriveInputImpl;

--- a/core/src/codegen/outer_from_impl.rs
+++ b/core/src/codegen/outer_from_impl.rs
@@ -2,8 +2,8 @@ use proc_macro2::TokenStream;
 use quote::{ToTokens, TokenStreamExt};
 use syn::{GenericParam, Generics, Path, TraitBound, TraitBoundModifier, TypeParamBound};
 
-use codegen::TraitImpl;
-use usage::IdentSet;
+use crate::codegen::TraitImpl;
+use crate::usage::IdentSet;
 
 /// Wrapper for "outer From" traits, such as `FromDeriveInput`, `FromVariant`, and `FromField`.
 pub trait OuterFromImpl<'a> {

--- a/core/src/codegen/trait_impl.rs
+++ b/core/src/codegen/trait_impl.rs
@@ -1,11 +1,12 @@
 use proc_macro2::TokenStream;
 use syn::{Generics, Ident, WherePredicate};
 
-use ast::{Data, Fields};
-use codegen::error::{ErrorCheck, ErrorDeclaration};
-use codegen::field;
-use codegen::{DefaultExpression, Field, FieldsGen, PostfixTransform, Variant};
-use usage::{CollectTypeParams, IdentSet, Purpose};
+use crate::ast::{Data, Fields};
+use crate::codegen::{
+    error::{ErrorCheck, ErrorDeclaration},
+    field, DefaultExpression, Field, FieldsGen, PostfixTransform, Variant,
+};
+use crate::usage::{CollectTypeParams, IdentSet, Purpose};
 
 #[derive(Debug)]
 pub struct TraitImpl<'a> {
@@ -86,7 +87,7 @@ impl<'a> TraitImpl<'a> {
     }
 
     /// Generate local variable declarations for all fields.
-    pub(in codegen) fn local_declarations(&self) -> TokenStream {
+    pub(in crate::codegen) fn local_declarations(&self) -> TokenStream {
         if let Data::Struct(ref vd) = self.data {
             let vdr = vd.as_ref().map(Field::as_declaration);
             let decls = vdr.fields.as_slice();
@@ -97,7 +98,7 @@ impl<'a> TraitImpl<'a> {
     }
 
     /// Generate immutable variable declarations for all fields.
-    pub(in codegen) fn immutable_declarations(&self) -> TokenStream {
+    pub(in crate::codegen) fn immutable_declarations(&self) -> TokenStream {
         if let Data::Struct(ref vd) = self.data {
             let vdr = vd.as_ref().map(|f| field::Declaration::new(f, false));
             let decls = vdr.fields.as_slice();
@@ -107,12 +108,12 @@ impl<'a> TraitImpl<'a> {
         }
     }
 
-    pub(in codegen) fn post_transform_call(&self) -> Option<TokenStream> {
+    pub(in crate::codegen) fn post_transform_call(&self) -> Option<TokenStream> {
         self.post_transform.map(|pt| quote!(#pt))
     }
 
     /// Generate local variable declaration and initialization for instance from which missing fields will be taken.
-    pub(in codegen) fn fallback_decl(&self) -> TokenStream {
+    pub(in crate::codegen) fn fallback_decl(&self) -> TokenStream {
         let default = self.default.as_ref().map(DefaultExpression::as_declaration);
         quote!(#default)
     }
@@ -127,12 +128,12 @@ impl<'a> TraitImpl<'a> {
         }
     }
 
-    pub(in codegen) fn initializers(&self) -> TokenStream {
+    pub(in crate::codegen) fn initializers(&self) -> TokenStream {
         self.make_field_ctx().initializers()
     }
 
     /// Generate the loop which walks meta items looking for property matches.
-    pub(in codegen) fn core_loop(&self) -> TokenStream {
+    pub(in crate::codegen) fn core_loop(&self) -> TokenStream {
         self.make_field_ctx().core_loop()
     }
 

--- a/core/src/codegen/variant.rs
+++ b/core/src/codegen/variant.rs
@@ -4,10 +4,10 @@ use proc_macro2::TokenStream;
 use quote::{ToTokens, TokenStreamExt};
 use syn::Ident;
 
-use ast::Fields;
-use codegen::error::{ErrorCheck, ErrorDeclaration};
-use codegen::{Field, FieldsGen};
-use usage::{self, IdentRefSet, IdentSet, UsesTypeParams};
+use crate::ast::Fields;
+use crate::codegen::error::{ErrorCheck, ErrorDeclaration};
+use crate::codegen::{Field, FieldsGen};
+use crate::usage::{self, IdentRefSet, IdentSet, UsesTypeParams};
 
 /// A variant of the enum which is deriving `FromMeta`.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/core/src/codegen/variant_data.rs
+++ b/core/src/codegen/variant_data.rs
@@ -1,8 +1,7 @@
 use proc_macro2::TokenStream;
 
-use ast::Fields;
-use ast::Style;
-use codegen::Field;
+use crate::ast::{Fields, Style};
+use crate::codegen::Field;
 
 pub struct FieldsGen<'a> {
     fields: &'a Fields<Field<'a>>,
@@ -18,7 +17,7 @@ impl<'a> FieldsGen<'a> {
     }
 
     /// Create declarations for all the fields in the struct.
-    pub(in codegen) fn declarations(&self) -> TokenStream {
+    pub(in crate::codegen) fn declarations(&self) -> TokenStream {
         match *self.fields {
             Fields {
                 style: Style::Struct,
@@ -33,7 +32,7 @@ impl<'a> FieldsGen<'a> {
     }
 
     /// Generate the loop which walks meta items looking for property matches.
-    pub(in codegen) fn core_loop(&self) -> TokenStream {
+    pub(in crate::codegen) fn core_loop(&self) -> TokenStream {
         let arms = self.fields.as_ref().map(Field::as_match);
 
         // If we're allowing unknown fields, then handling one is a no-op.
@@ -84,7 +83,7 @@ impl<'a> FieldsGen<'a> {
         }
     }
 
-    pub(in codegen) fn initializers(&self) -> TokenStream {
+    pub(in crate::codegen) fn initializers(&self) -> TokenStream {
         let inits = self.fields.as_ref().map(Field::as_initializer);
         let inits = inits.iter();
 

--- a/core/src/derive.rs
+++ b/core/src/derive.rs
@@ -5,7 +5,7 @@ use proc_macro2::TokenStream;
 use quote::ToTokens;
 use syn::DeriveInput;
 
-use options;
+use crate::options;
 
 /// Run an expression which returns a `darling::Result`, then either return the tokenized
 /// representation of the `Ok` value, or the tokens of the compiler errors in the `Err` case.

--- a/core/src/error/kind.rs
+++ b/core/src/error/kind.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use error::Error;
+use crate::error::Error;
 
 type DeriveInputShape = String;
 type FieldName = String;
@@ -10,7 +10,7 @@ type MetaFormat = String;
 // Don't want to publicly commit to ErrorKind supporting equality yet, but
 // not having it makes testing very difficult.
 #[cfg_attr(test, derive(Clone, PartialEq, Eq))]
-pub(in error) enum ErrorKind {
+pub(in crate::error) enum ErrorKind {
     /// An arbitrary error message.
     Custom(String),
     DuplicateField(FieldName),
@@ -108,7 +108,7 @@ impl From<ErrorUnknownField> for ErrorKind {
 // Don't want to publicly commit to ErrorKind supporting equality yet, but
 // not having it makes testing very difficult.
 #[cfg_attr(test, derive(Clone, PartialEq, Eq))]
-pub(in error) struct ErrorUnknownField {
+pub(in crate::error) struct ErrorUnknownField {
     name: String,
     did_you_mean: Option<String>,
 }

--- a/core/src/error/mod.rs
+++ b/core/src/error/mod.rs
@@ -74,7 +74,7 @@ fn path_to_string(path: &syn::Path) -> String {
 
 /// Error creation functions
 impl Error {
-    pub(in error) fn new(kind: ErrorKind) -> Self {
+    pub(in crate::error) fn new(kind: ErrorKind) -> Self {
         Error {
             kind,
             locations: Vec::new(),

--- a/core/src/from_derive_input.rs
+++ b/core/src/from_derive_input.rs
@@ -1,6 +1,6 @@
 use syn::DeriveInput;
 
-use Result;
+use crate::Result;
 
 /// Creates an instance by parsing an entire proc-macro `derive` input,
 /// including the, identity, generics, and visibility of the type.

--- a/core/src/from_field.rs
+++ b/core/src/from_field.rs
@@ -1,6 +1,6 @@
-use syn::{self, Field};
+use syn::Field;
 
-use Result;
+use crate::Result;
 
 /// Creates an instance by parsing an individual field and its attributes.
 pub trait FromField: Sized {

--- a/core/src/from_generic_param.rs
+++ b/core/src/from_generic_param.rs
@@ -1,6 +1,4 @@
-use syn;
-
-use Result;
+use crate::Result;
 
 /// Creates an instance by parsing a specific `syn::GenericParam`.
 /// This can be a type param, a lifetime, or a const param.

--- a/core/src/from_generics.rs
+++ b/core/src/from_generics.rs
@@ -1,6 +1,6 @@
 use syn::Generics;
 
-use Result;
+use crate::Result;
 
 /// Creates an instance by parsing an entire generics declaration, including the
 /// `where` clause.

--- a/core/src/from_meta.rs
+++ b/core/src/from_meta.rs
@@ -7,10 +7,9 @@ use std::rc::Rc;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
-use ident_case;
-use syn::{self, Expr, Lit, Meta, NestedMeta};
+use syn::{Expr, Lit, Meta, NestedMeta};
 
-use {Error, Result};
+use crate::{Error, Result};
 
 /// Create an instance from an item in an attribute declaration.
 ///
@@ -584,9 +583,8 @@ hash_map!(syn::Path);
 #[cfg(test)]
 mod tests {
     use proc_macro2::TokenStream;
-    use syn;
 
-    use {Error, FromMeta, Result};
+    use crate::{Error, FromMeta, Result};
 
     /// parse a string as a syn::Meta instance.
     fn pm(tokens: TokenStream) -> ::std::result::Result<syn::Meta, String> {

--- a/core/src/from_type_param.rs
+++ b/core/src/from_type_param.rs
@@ -1,6 +1,6 @@
-use syn::{self, TypeParam};
+use syn::TypeParam;
 
-use Result;
+use crate::Result;
 
 /// Creates an instance by parsing an individual type_param and its attributes.
 pub trait FromTypeParam: Sized {

--- a/core/src/from_variant.rs
+++ b/core/src/from_variant.rs
@@ -1,6 +1,6 @@
-use syn::{self, Variant};
+use syn::Variant;
 
-use Result;
+use crate::Result;
 
 /// Creates an instance from a specified `syn::Variant`.
 pub trait FromVariant: Sized {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -33,14 +33,14 @@ pub(crate) mod options;
 pub mod usage;
 pub mod util;
 
-pub use error::{Error, Result};
-pub use from_derive_input::FromDeriveInput;
-pub use from_field::FromField;
-pub use from_generic_param::FromGenericParam;
-pub use from_generics::FromGenerics;
-pub use from_meta::FromMeta;
-pub use from_type_param::FromTypeParam;
-pub use from_variant::FromVariant;
+pub use self::error::{Error, Result};
+pub use self::from_derive_input::FromDeriveInput;
+pub use self::from_field::FromField;
+pub use self::from_generic_param::FromGenericParam;
+pub use self::from_generics::FromGenerics;
+pub use self::from_meta::FromMeta;
+pub use self::from_type_param::FromTypeParam;
+pub use self::from_variant::FromVariant;
 
 // Re-export tokenizer
 #[doc(hidden)]

--- a/core/src/macros_public.rs
+++ b/core/src/macros_public.rs
@@ -12,9 +12,7 @@
 ///
 /// ```rust
 /// # extern crate syn;
-/// #
-/// # #[macro_use]
-/// # extern crate darling_core;
+/// # use darling_core::uses_type_params;
 /// #
 /// struct MyField {
 ///     ty: syn::Type,

--- a/core/src/options/core.rs
+++ b/core/src/options/core.rs
@@ -1,12 +1,11 @@
 use ident_case::RenameRule;
-use syn;
 
-use ast::{Data, Fields, Style};
-use codegen;
-use codegen::PostfixTransform;
-use options::{DefaultExpression, InputField, InputVariant, ParseAttribute, ParseData};
-use util::Flag;
-use {Error, FromMeta, Result};
+use crate::ast::{Data, Fields, Style};
+use crate::codegen;
+use crate::codegen::PostfixTransform;
+use crate::options::{DefaultExpression, InputField, InputVariant, ParseAttribute, ParseData};
+use crate::util::Flag;
+use crate::{Error, FromMeta, Result};
 
 /// A struct or enum which should have `FromMeta` or `FromDeriveInput` implementations
 /// generated.

--- a/core/src/options/forward_attrs.rs
+++ b/core/src/options/forward_attrs.rs
@@ -1,7 +1,7 @@
 use syn::NestedMeta;
 
-use util::PathList;
-use {FromMeta, Result};
+use crate::util::PathList;
+use crate::{FromMeta, Result};
 
 /// A rule about which attributes to forward to the generated struct.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/core/src/options/from_derive.rs
+++ b/core/src/options/from_derive.rs
@@ -1,10 +1,10 @@
 use proc_macro2::TokenStream;
 use quote::ToTokens;
-use syn::{self, Ident};
+use syn::Ident;
 
-use codegen::FromDeriveInputImpl;
-use options::{OuterFrom, ParseAttribute, ParseData, Shape};
-use {FromMeta, Result};
+use crate::codegen::FromDeriveInputImpl;
+use crate::options::{OuterFrom, ParseAttribute, ParseData, Shape};
+use crate::{FromMeta, Result};
 
 #[derive(Debug)]
 pub struct FdiOptions {

--- a/core/src/options/from_field.rs
+++ b/core/src/options/from_field.rs
@@ -1,10 +1,10 @@
 use proc_macro2::TokenStream;
 use quote::ToTokens;
-use syn::{self, Ident};
+use syn::Ident;
 
-use codegen::FromFieldImpl;
-use options::{OuterFrom, ParseAttribute, ParseData};
-use Result;
+use crate::codegen::FromFieldImpl;
+use crate::options::{OuterFrom, ParseAttribute, ParseData};
+use crate::Result;
 
 #[derive(Debug)]
 pub struct FromFieldOptions {

--- a/core/src/options/from_meta.rs
+++ b/core/src/options/from_meta.rs
@@ -1,10 +1,9 @@
 use proc_macro2::TokenStream;
 use quote::ToTokens;
-use syn;
 
-use codegen::FromMetaImpl;
-use options::{Core, ParseAttribute, ParseData};
-use Result;
+use crate::codegen::FromMetaImpl;
+use crate::options::{Core, ParseAttribute, ParseData};
+use crate::Result;
 
 pub struct FromMetaOptions {
     base: Core,

--- a/core/src/options/from_type_param.rs
+++ b/core/src/options/from_type_param.rs
@@ -1,10 +1,10 @@
 use proc_macro2::TokenStream;
 use quote::ToTokens;
-use syn::{self, Ident};
+use syn::Ident;
 
-use codegen::FromTypeParamImpl;
-use options::{OuterFrom, ParseAttribute, ParseData};
-use Result;
+use crate::codegen::FromTypeParamImpl;
+use crate::options::{OuterFrom, ParseAttribute, ParseData};
+use crate::Result;
 
 #[derive(Debug)]
 pub struct FromTypeParamOptions {

--- a/core/src/options/from_variant.rs
+++ b/core/src/options/from_variant.rs
@@ -2,9 +2,9 @@ use proc_macro2::TokenStream;
 use quote::ToTokens;
 use syn::{DeriveInput, Field, Ident, Meta};
 
-use codegen::FromVariantImpl;
-use options::{DataShape, OuterFrom, ParseAttribute, ParseData};
-use {FromMeta, Result};
+use crate::codegen::FromVariantImpl;
+use crate::options::{DataShape, OuterFrom, ParseAttribute, ParseData};
+use crate::{FromMeta, Result};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FromVariantOptions {

--- a/core/src/options/input_field.rs
+++ b/core/src/options/input_field.rs
@@ -1,10 +1,8 @@
 use std::borrow::Cow;
 
-use syn;
-
-use codegen;
-use options::{Core, DefaultExpression, ParseAttribute};
-use {Error, FromMeta, Result};
+use crate::codegen;
+use crate::options::{Core, DefaultExpression, ParseAttribute};
+use crate::{Error, FromMeta, Result};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InputField {

--- a/core/src/options/input_variant.rs
+++ b/core/src/options/input_variant.rs
@@ -1,11 +1,9 @@
 use std::borrow::Cow;
 
-use syn;
-
-use ast::Fields;
-use codegen;
-use options::{Core, InputField, ParseAttribute};
-use {Error, FromMeta, Result};
+use crate::ast::Fields;
+use crate::codegen;
+use crate::options::{Core, InputField, ParseAttribute};
+use crate::{Error, FromMeta, Result};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InputVariant {

--- a/core/src/options/mod.rs
+++ b/core/src/options/mod.rs
@@ -1,6 +1,4 @@
-use syn;
-
-use {Error, FromMeta, Result};
+use crate::{Error, FromMeta, Result};
 
 mod core;
 mod forward_attrs;

--- a/core/src/options/outer_from.rs
+++ b/core/src/options/outer_from.rs
@@ -1,8 +1,8 @@
-use syn::{self, Field, Ident, Meta};
+use syn::{Field, Ident, Meta};
 
-use options::{Core, DefaultExpression, ForwardAttrs, ParseAttribute, ParseData};
-use util::PathList;
-use {FromMeta, Result};
+use crate::options::{Core, DefaultExpression, ForwardAttrs, ParseAttribute, ParseData};
+use crate::util::PathList;
+use crate::{FromMeta, Result};
 
 /// Reusable base for `FromDeriveInput`, `FromVariant`, `FromField`, and other top-level
 /// `From*` traits.

--- a/core/src/options/shape.rs
+++ b/core/src/options/shape.rs
@@ -5,7 +5,7 @@ use proc_macro2::TokenStream;
 use quote::{ToTokens, TokenStreamExt};
 use syn::{Meta, NestedMeta};
 
-use {Error, FromMeta, Result};
+use crate::{Error, FromMeta, Result};
 
 /// Receiver struct for shape validation. Shape validation allows a deriving type
 /// to declare that it only accepts - for example - named structs, or newtype enum
@@ -228,10 +228,9 @@ fn match_arm(name: &'static str, is_supported: bool) -> TokenStream {
 #[cfg(test)]
 mod tests {
     use proc_macro2::TokenStream;
-    use syn;
 
     use super::Shape;
-    use FromMeta;
+    use crate::FromMeta;
 
     /// parse a string as a syn::Meta instance.
     fn pm(tokens: TokenStream) -> ::std::result::Result<syn::Meta, String> {

--- a/core/src/usage/generics_ext.rs
+++ b/core/src/usage/generics_ext.rs
@@ -1,6 +1,6 @@
 use syn::Generics;
 
-use usage::{IdentSet, LifetimeSet};
+use crate::usage::{IdentSet, LifetimeSet};
 
 /// Extension trait for pulling specific generics data from a generics AST representation.
 pub trait GenericsExt {

--- a/core/src/usage/lifetimes.rs
+++ b/core/src/usage/lifetimes.rs
@@ -1,8 +1,8 @@
 use fnv::FnvHashSet;
 use syn::punctuated::Punctuated;
-use syn::{self, Lifetime, Type};
+use syn::{Lifetime, Type};
 
-use usage::Options;
+use crate::usage::Options;
 
 /// A set of lifetimes.
 pub type LifetimeSet = FnvHashSet<Lifetime>;
@@ -282,11 +282,11 @@ impl UsesLifetimes for syn::TypeParamBound {
 #[cfg(test)]
 mod tests {
     use proc_macro2::Span;
-    use syn::{self, DeriveInput};
+    use syn::DeriveInput;
 
     use super::UsesLifetimes;
-    use usage::GenericsExt;
-    use usage::Purpose::*;
+    use crate::usage::GenericsExt;
+    use crate::usage::Purpose::*;
 
     #[test]
     fn struct_named() {

--- a/core/src/usage/type_params.rs
+++ b/core/src/usage/type_params.rs
@@ -1,7 +1,7 @@
 use syn::punctuated::Punctuated;
-use syn::{self, Ident, Type};
+use syn::{Ident, Type};
 
-use usage::{IdentRefSet, IdentSet, Options};
+use crate::usage::{IdentRefSet, IdentSet, Options};
 
 /// Searcher for finding type params in a syntax tree.
 /// This can be used to determine if a given type parameter needs to be bounded in a generated impl.
@@ -250,8 +250,8 @@ mod tests {
     use syn::{DeriveInput, Ident};
 
     use super::UsesTypeParams;
-    use usage::IdentSet;
-    use usage::Purpose::*;
+    use crate::usage::IdentSet;
+    use crate::usage::Purpose::*;
 
     fn ident_set(idents: Vec<&str>) -> IdentSet {
         idents

--- a/core/src/util/ident_string.rs
+++ b/core/src/util/ident_string.rs
@@ -5,7 +5,7 @@ use proc_macro2::{Span, TokenStream};
 use quote::ToTokens;
 use syn::{Ident, Meta};
 
-use {FromMeta, Result};
+use crate::{FromMeta, Result};
 
 /// A wrapper for an `Ident` which also keeps the value as a string.
 ///

--- a/core/src/util/ignored.rs
+++ b/core/src/util/ignored.rs
@@ -1,7 +1,5 @@
-use syn;
-
-use usage::{self, UsesLifetimes, UsesTypeParams};
-use {
+use crate::{
+    usage::{self, UsesLifetimes, UsesTypeParams},
     FromDeriveInput, FromField, FromGenericParam, FromGenerics, FromMeta, FromTypeParam,
     FromVariant, Result,
 };

--- a/core/src/util/mod.rs
+++ b/core/src/util/mod.rs
@@ -2,8 +2,7 @@
 
 use std::ops::{BitAnd, BitOr, Deref, Not};
 
-use syn;
-use {FromMeta, Result};
+use crate::{FromMeta, Result};
 
 mod ident_string;
 mod ignored;

--- a/core/src/util/over_ride.rs
+++ b/core/src/util/over_ride.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use syn::{Lit, NestedMeta};
 
-use {FromMeta, Result};
+use crate::{FromMeta, Result};
 
 use self::Override::*;
 
@@ -17,10 +17,7 @@ use self::Override::*;
 /// In a struct collecting input for this attribute, that would be written as:
 ///
 /// ```rust,ignore
-/// # #[macro_use]
-/// # extern crate darling;
-/// # extern crate syn;
-/// use darling::util::Override;
+/// use darling::{util::Override, FromField};
 /// #[derive(FromField)]
 /// #[darling(attributes(darling))]
 /// pub struct Options {

--- a/core/src/util/path_list.rs
+++ b/core/src/util/path_list.rs
@@ -3,7 +3,7 @@ use std::string::ToString;
 
 use syn::{Meta, NestedMeta, Path};
 
-use {Error, FromMeta, Result};
+use crate::{Error, FromMeta, Result};
 
 /// A list of `syn::Path` instances. This type is used to extract a list of paths from an
 /// attribute.
@@ -72,9 +72,9 @@ impl FromMeta for PathList {
 #[cfg(test)]
 mod tests {
     use super::PathList;
+    use crate::FromMeta;
     use proc_macro2::TokenStream;
     use syn::{Attribute, Meta};
-    use FromMeta;
 
     /// parse a string as a syn::Meta instance.
     fn pm(tokens: TokenStream) -> ::std::result::Result<Meta, String> {

--- a/core/src/util/spanned_value.rs
+++ b/core/src/util/spanned_value.rs
@@ -1,8 +1,8 @@
 use proc_macro2::Span;
 use std::ops::{Deref, DerefMut};
-use syn;
 use syn::spanned::Spanned;
-use {
+
+use crate::{
     FromDeriveInput, FromField, FromGenericParam, FromGenerics, FromMeta, FromTypeParam,
     FromVariant, Result,
 };

--- a/core/src/util/with_original.rs
+++ b/core/src/util/with_original.rs
@@ -1,6 +1,4 @@
-use syn;
-
-use {
+use crate::{
     FromDeriveInput, FromField, FromGenericParam, FromGenerics, FromMeta, FromTypeParam,
     FromVariant, Result,
 };

--- a/examples/automatic_bounds.rs
+++ b/examples/automatic_bounds.rs
@@ -1,9 +1,4 @@
-#[macro_use]
-extern crate darling;
-
-extern crate syn;
-
-use darling::FromDeriveInput;
+use darling::{FromDeriveInput, FromMeta};
 
 #[derive(FromMeta, PartialEq, Eq, Debug)]
 enum Volume {

--- a/examples/consume_fields.rs
+++ b/examples/consume_fields.rs
@@ -1,16 +1,8 @@
 //! This example shows how to do struct and field parsing using darling.
 
-#[macro_use]
-extern crate darling;
-extern crate proc_macro2;
-#[macro_use]
-extern crate quote;
-extern crate syn;
-
-use darling::ast;
-use darling::FromDeriveInput;
+use darling::{ast, FromDeriveInput, FromField, FromMeta};
 use proc_macro2::TokenStream;
-use quote::ToTokens;
+use quote::{quote, ToTokens};
 use syn::parse_str;
 
 /// A speaking volume. Deriving `FromMeta` will cause this to be usable

--- a/examples/fallible_read.rs
+++ b/examples/fallible_read.rs
@@ -5,10 +5,6 @@
 //! 1. Using `Result<T, syn::Meta>` to attempt a recovery in imperative code
 //! 1. Using the `map` darling meta-item to post-process a field before returning
 //! 1. Using the `and_then` darling meta-item to post-process the receiver before returning
-#[macro_use]
-extern crate darling;
-
-extern crate syn;
 
 use darling::{FromDeriveInput, FromMeta};
 use syn::parse_str;

--- a/examples/supports_struct.rs
+++ b/examples/supports_struct.rs
@@ -1,9 +1,4 @@
-#[macro_use]
-extern crate darling;
-
-extern crate syn;
-
-use darling::{ast, util, FromDeriveInput};
+use darling::{ast, util, FromDeriveInput, FromField};
 use syn::{Ident, Type};
 
 #[derive(Debug, FromField)]

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -11,8 +11,8 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
-quote = "1"
-syn = "1"
+quote = "1.0.9"
+syn = "1.0.69"
 darling_core = { version = "=0.12.4", path = "../core" }
 
 [lib]

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -8,6 +8,7 @@ Internal support for a proc-macro library for reading attributes into structs wh
 implementing custom derives. Use https://crates.io/crates/darling in your code.
 """
 license = "MIT"
+edition = "2018"
 
 [dependencies]
 quote = "1"

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -1,12 +1,9 @@
+// This is needed for 1.31.0 to keep compiling
 extern crate proc_macro;
-#[macro_use]
-extern crate syn;
-
-extern crate darling_core;
-
-use proc_macro::TokenStream;
 
 use darling_core::{derive, Error};
+use proc_macro::TokenStream;
+use syn::parse_macro_input;
 
 #[proc_macro_derive(FromMeta, attributes(darling))]
 pub fn derive_from_meta(input: TokenStream) -> TokenStream {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,6 @@
 //! |`attrs`|`Vec<syn::Attribute>`|The forwarded attributes from the passed in variant. These are controlled using the `forward_attrs` attribute.|
 
 extern crate core;
-extern crate darling_core;
 
 #[allow(unused_imports)]
 #[macro_use]

--- a/tests/accrue_errors.rs
+++ b/tests/accrue_errors.rs
@@ -1,15 +1,8 @@
 //! These tests verify that multiple errors will be collected up from throughout
 //! the parsing process and returned correctly to the caller.
 
-#[macro_use]
-extern crate darling;
-#[macro_use]
-extern crate syn;
-#[macro_use]
-extern crate quote;
-
-use darling::ast;
-use darling::FromDeriveInput;
+use darling::{ast, FromDeriveInput, FromField, FromMeta};
+use syn::parse_quote;
 
 #[derive(Debug, FromDeriveInput)]
 #[darling(attributes(accrue))]

--- a/tests/computed_bound.rs
+++ b/tests/computed_bound.rs
@@ -1,8 +1,4 @@
-#[macro_use]
-extern crate darling;
-extern crate syn;
-
-use darling::FromDeriveInput;
+use darling::{FromDeriveInput, FromMeta};
 
 fn parse<T: FromDeriveInput>(src: &str) -> T {
     let ast = syn::parse_str(src).unwrap();

--- a/tests/custom_bound.rs
+++ b/tests/custom_bound.rs
@@ -1,8 +1,6 @@
-#[macro_use]
-extern crate darling;
-extern crate syn;
-
 use std::ops::Add;
+
+use darling::{FromDeriveInput, FromMeta};
 
 #[derive(Debug, Clone, FromMeta)]
 #[darling(bound = "T: FromMeta + Add")]

--- a/tests/defaults.rs
+++ b/tests/defaults.rs
@@ -1,11 +1,5 @@
-#[macro_use]
-extern crate darling;
-#[macro_use]
-extern crate quote;
-#[macro_use]
-extern crate syn;
-
 use darling::FromDeriveInput;
+use syn::parse_quote;
 
 mod foo {
     pub mod bar {

--- a/tests/enums_newtype.rs
+++ b/tests/enums_newtype.rs
@@ -1,11 +1,5 @@
-#[macro_use]
-extern crate darling;
-#[macro_use]
-extern crate syn;
-#[macro_use]
-extern crate quote;
-
-use darling::FromDeriveInput;
+use darling::{FromDeriveInput, FromMeta};
+use syn::parse_quote;
 
 #[derive(Debug, Default, PartialEq, Eq, FromMeta)]
 #[darling(default)]

--- a/tests/enums_struct.rs
+++ b/tests/enums_struct.rs
@@ -1,9 +1,6 @@
 //! Test expansion of enums which have struct variants.
 
-#[macro_use]
-extern crate darling;
-extern crate syn;
-
+use darling::FromMeta;
 #[derive(Debug, FromMeta)]
 #[darling(rename_all = "snake_case")]
 enum Message {

--- a/tests/enums_unit.rs
+++ b/tests/enums_unit.rs
@@ -1,8 +1,6 @@
 //! Test expansion of enum variants which have no associated data.
 
-#[macro_use]
-extern crate darling;
-extern crate syn;
+use darling::FromMeta;
 
 #[derive(Debug, FromMeta)]
 #[darling(rename_all = "snake_case")]

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -1,12 +1,7 @@
 //! In case of bad input, parsing should fail. The error should have locations set in derived implementations.
-#[macro_use]
-extern crate darling;
-#[macro_use]
-extern crate syn;
-#[macro_use]
-extern crate quote;
 
-use darling::FromDeriveInput;
+use darling::{FromDeriveInput, FromMeta};
+use syn::parse_quote;
 
 #[derive(Debug, FromMeta)]
 struct Dolor {

--- a/tests/from_generics.rs
+++ b/tests/from_generics.rs
@@ -2,13 +2,11 @@
 //! These tests assume `FromTypeParam` is working and only look at whether the wrappers for magic
 //! fields are working as expected.
 
-#[macro_use]
-extern crate darling;
-extern crate syn;
-
-use darling::ast::{self, GenericParamExt};
-use darling::util::{Ignored, WithOriginal};
-use darling::{FromDeriveInput, Result};
+use darling::{
+    ast::{self, GenericParamExt},
+    util::{Ignored, WithOriginal},
+    FromDeriveInput, FromTypeParam, Result,
+};
 
 #[derive(FromDeriveInput)]
 #[darling(attributes(lorem))]

--- a/tests/from_type_param.rs
+++ b/tests/from_type_param.rs
@@ -1,12 +1,5 @@
-#[macro_use]
-extern crate darling;
-#[macro_use]
-extern crate syn;
-#[macro_use]
-extern crate quote;
-
 use darling::FromTypeParam;
-use syn::{DeriveInput, GenericParam, Ident, TypeParam};
+use syn::{parse_quote, DeriveInput, GenericParam, Ident, TypeParam};
 
 #[darling(attributes(lorem), from_ident)]
 #[derive(FromTypeParam)]

--- a/tests/from_type_param_default.rs
+++ b/tests/from_type_param_default.rs
@@ -1,12 +1,5 @@
-#[macro_use]
-extern crate darling;
-#[macro_use]
-extern crate syn;
-#[macro_use]
-extern crate quote;
-
 use darling::FromTypeParam;
-use syn::{DeriveInput, GenericParam, TypeParam};
+use syn::{parse_quote, DeriveInput, GenericParam, TypeParam};
 
 #[darling(attributes(lorem), default)]
 #[derive(Default, FromTypeParam)]

--- a/tests/from_variant.rs
+++ b/tests/from_variant.rs
@@ -1,7 +1,3 @@
-#[macro_use]
-extern crate darling;
-extern crate syn;
-
 use darling::FromVariant;
 use syn::{spanned::Spanned, Expr, ExprLit, LitInt};
 

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -1,11 +1,5 @@
-#[macro_use]
-extern crate darling;
-#[macro_use]
-extern crate syn;
-#[macro_use]
-extern crate quote;
-
-use darling::FromDeriveInput;
+use darling::{FromDeriveInput, FromMeta};
+use syn::parse_quote;
 
 #[derive(Debug, Clone, FromMeta)]
 struct Wrapper<T>(pub T);

--- a/tests/happy_path.rs
+++ b/tests/happy_path.rs
@@ -1,11 +1,5 @@
-#[macro_use]
-extern crate darling;
-#[macro_use]
-extern crate syn;
-#[macro_use]
-extern crate quote;
-
-use darling::FromDeriveInput;
+use darling::{FromDeriveInput, FromMeta};
+use syn::parse_quote;
 
 #[derive(Default, FromMeta, PartialEq, Debug)]
 #[darling(default)]

--- a/tests/hash_map.rs
+++ b/tests/hash_map.rs
@@ -1,14 +1,7 @@
-#[macro_use]
-extern crate darling;
-#[macro_use]
-extern crate syn;
-#[macro_use]
-extern crate quote;
-
 use std::collections::HashMap;
 
 use darling::FromMeta;
-use syn::{Attribute, Path};
+use syn::{parse_quote, Attribute, Path};
 
 #[derive(Debug, FromMeta, PartialEq, Eq)]
 struct MapValue {

--- a/tests/multiple.rs
+++ b/tests/multiple.rs
@@ -1,11 +1,5 @@
-#[macro_use]
-extern crate darling;
-#[macro_use]
-extern crate syn;
-#[macro_use]
-extern crate quote;
-
-use darling::FromDeriveInput;
+use darling::{FromDeriveInput, FromMeta};
+use syn::parse_quote;
 
 #[derive(FromDeriveInput)]
 #[darling(attributes(hello))]

--- a/tests/newtype.rs
+++ b/tests/newtype.rs
@@ -1,13 +1,7 @@
 //! A newtype struct should be able to derive `FromMeta` if its member implements it.
 
-#[macro_use]
-extern crate darling;
-#[macro_use]
-extern crate syn;
-#[macro_use]
-extern crate quote;
-
-use darling::FromDeriveInput;
+use darling::{FromDeriveInput, FromMeta};
+use syn::parse_quote;
 
 #[derive(Debug, FromMeta, PartialEq, Eq)]
 struct Lorem(bool);

--- a/tests/skip.rs
+++ b/tests/skip.rs
@@ -1,13 +1,7 @@
 //! Test that skipped fields are not read into structs when they appear in input.
 
-#[macro_use]
-extern crate darling;
-#[macro_use]
-extern crate syn;
-#[macro_use]
-extern crate quote;
-
-use darling::FromDeriveInput;
+use darling::{FromDeriveInput, FromMeta};
+use syn::parse_quote;
 
 #[derive(Debug, PartialEq, Eq, FromDeriveInput)]
 #[darling(attributes(skip_test))]

--- a/tests/split_declaration.rs
+++ b/tests/split_declaration.rs
@@ -1,16 +1,8 @@
 //! When input is split across multiple attributes on one element,
 //! darling should collapse that into one struct.
 
-#[macro_use]
-extern crate darling;
-#[macro_use]
-extern crate syn;
-#[macro_use]
-extern crate quote;
-
-use std::string::ToString;
-
 use darling::{Error, FromDeriveInput};
+use syn::parse_quote;
 
 #[derive(Debug, FromDeriveInput, PartialEq, Eq)]
 #[darling(attributes(split))]

--- a/tests/suggestions.rs
+++ b/tests/suggestions.rs
@@ -1,13 +1,7 @@
 #![cfg(feature = "suggestions")]
 
-#[macro_use]
-extern crate darling;
-#[macro_use]
-extern crate syn;
-#[macro_use]
-extern crate quote;
-
-use darling::FromDeriveInput;
+use darling::{FromDeriveInput, FromMeta};
+use syn::parse_quote;
 
 #[derive(Debug, FromDeriveInput)]
 #[darling(attributes(suggest))]

--- a/tests/supports.rs
+++ b/tests/supports.rs
@@ -1,12 +1,4 @@
-#[macro_use]
-extern crate darling;
-#[macro_use]
-extern crate syn;
-#[macro_use]
-extern crate quote;
-
-use darling::ast;
-use darling::FromDeriveInput;
+use darling::{ast, FromDeriveInput, FromVariant};
 
 #[derive(Debug, FromDeriveInput)]
 #[darling(attributes(from_variants), supports(enum_any))]
@@ -28,7 +20,7 @@ pub struct StructContainer {
 }
 
 mod source {
-    use syn::DeriveInput;
+    use syn::{parse_quote, DeriveInput};
 
     pub fn newtype_enum() -> DeriveInput {
         parse_quote! {

--- a/tests/unsupported_attributes.rs
+++ b/tests/unsupported_attributes.rs
@@ -1,10 +1,5 @@
-#[macro_use]
-extern crate darling;
-#[macro_use]
-extern crate syn;
-
 use darling::FromDeriveInput;
-use syn::{Ident, LitStr, Path};
+use syn::{parse_quote, Ident, LitStr, Path};
 
 #[derive(Debug, FromDeriveInput)]
 #[darling(supports(struct_unit), attributes(bar))]


### PR DESCRIPTION
* Fix relative visibility
* Fix imports to use crate::
* Remove most unnecessary macro imports
* Fix all warnings in tests and examples

First step of #127