### PR TITLE
Another Clippy PR part 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,12 +64,12 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
           override: true
           components: clippy
       - uses: Swatinem/rust-cache@v1
-      - name: Run clippy --workspace --all-features --tests
-        run: cargo clippy --workspace --all-features --tests
+      - name: Run clippy --workspace --tests
+        run: cargo clippy --workspace --tests
 
   rustfmt:
     name: Verify code formatting

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,2 @@
 msrv = "1.31.0"
+blacklisted-names = [] # we want to be able to use placeholder names in tests

--- a/core/src/error/kind.rs
+++ b/core/src/error/kind.rs
@@ -130,7 +130,7 @@ impl ErrorUnknownField {
     }
 
     #[cfg(feature = "diagnostics")]
-    pub fn to_diagnostic(self, span: Option<::proc_macro2::Span>) -> ::proc_macro::Diagnostic {
+    pub fn into_diagnostic(self, span: Option<::proc_macro2::Span>) -> ::proc_macro::Diagnostic {
         let base = span
             .unwrap_or_else(::proc_macro2::Span::call_site)
             .unwrap()

--- a/core/src/error/mod.rs
+++ b/core/src/error/mod.rs
@@ -224,6 +224,7 @@ impl Error {
 }
 
 /// Error instance methods
+#[allow(clippy::len_without_is_empty)] // Error can never be empty
 impl Error {
     /// Check if this error is associated with a span in the token stream.
     pub fn has_span(&self) -> bool {
@@ -285,7 +286,6 @@ impl Error {
     ///
     /// This function never returns `0`, as it's impossible to construct
     /// a multi-error from an empty `Vec`.
-    #[allow(clippy::len_without_is_empty)] // Error can never be empty
     pub fn len(&self) -> usize {
         self.kind.len()
     }

--- a/core/src/error/mod.rs
+++ b/core/src/error/mod.rs
@@ -358,7 +358,7 @@ impl Error {
         // If span information is available, don't include the error property path
         // since it's redundant and not consistent with native compiler diagnostics.
         match self.kind {
-            ErrorKind::UnknownField(euf) => euf.to_diagnostic(self.span),
+            ErrorKind::UnknownField(euf) => euf.into_diagnostic(self.span),
             _ => match self.span {
                 Some(span) => span.unwrap().error(self.kind.to_string()),
                 None => Diagnostic::new(Level::Error, self.to_string()),

--- a/core/src/from_meta.rs
+++ b/core/src/from_meta.rs
@@ -139,6 +139,7 @@ impl FromMeta for bool {
         Ok(true)
     }
 
+    #[allow(clippy::wrong_self_convention)] // false positive
     fn from_bool(value: bool) -> Result<Self> {
         Ok(value)
     }
@@ -157,6 +158,7 @@ impl FromMeta for AtomicBool {
 }
 
 impl FromMeta for char {
+    #[allow(clippy::wrong_self_convention)] // false positive
     fn from_char(value: char) -> Result<Self> {
         Ok(value)
     }

--- a/core/src/options/input_field.rs
+++ b/core/src/options/input_field.rs
@@ -71,16 +71,16 @@ impl InputField {
         let ty = f.ty.clone();
         let base = Self::new(ident, ty).parse_attributes(&f.attrs)?;
 
-        if let Some(container) = parent {
+        Ok(if let Some(container) = parent {
             base.with_inherited(container)
         } else {
-            Ok(base)
-        }
+            base
+        })
     }
 
     /// Apply inherited settings from the container. This is done _after_ parsing
     /// to ensure deference to explicit field-level settings.
-    fn with_inherited(mut self, parent: &Core) -> Result<Self> {
+    fn with_inherited(mut self, parent: &Core) -> Self {
         // explicit renamings take precedence over rename rules on the container,
         // but in the absence of an explicit name we apply the rule.
         if self.attr_name.is_none() {
@@ -111,7 +111,7 @@ impl InputField {
             (false, false, false) => None,
         };
 
-        Ok(self)
+        self
     }
 }
 

--- a/tests/from_generics.rs
+++ b/tests/from_generics.rs
@@ -132,15 +132,7 @@ fn with_original() {
 
     // Make sure we haven't lost anything in the conversion
     assert_eq!(rec.generics.parsed.params.len(), 3);
-    assert_eq!(
-        rec.generics
-            .original
-            .params
-            .iter()
-            .collect::<Vec<_>>()
-            .len(),
-        3
-    );
+    assert_eq!(rec.generics.original.params.len(), 3);
 
     let parsed_t: &MyTypeParam = rec.generics.parsed.params[1]
         .as_type_param()

--- a/tests/from_type_param.rs
+++ b/tests/from_type_param.rs
@@ -1,8 +1,8 @@
 use darling::FromTypeParam;
 use syn::{parse_quote, DeriveInput, GenericParam, Ident, TypeParam};
 
-#[darling(attributes(lorem), from_ident)]
 #[derive(FromTypeParam)]
+#[darling(attributes(lorem), from_ident)]
 struct Lorem {
     ident: Ident,
     bounds: Vec<syn::TypeParamBound>,

--- a/tests/from_type_param_default.rs
+++ b/tests/from_type_param_default.rs
@@ -1,8 +1,8 @@
 use darling::FromTypeParam;
 use syn::{parse_quote, DeriveInput, GenericParam, TypeParam};
 
-#[darling(attributes(lorem), default)]
 #[derive(Default, FromTypeParam)]
+#[darling(attributes(lorem), default)]
 struct Lorem {
     foo: bool,
     bar: Option<String>,


### PR DESCRIPTION
After #132, this PR introduces Clippy into GitHub Actions CI and also fixes a few lints that I didn't catch in the previous pull request because I forgot to use newest Clippy, turn on all features, and turn on lints for tests (those things are now enabled in CI so hopefully nobody can forget again).

The workflow code is slightly adapted from https://github.com/chipsenkbeil/entity-rs/blob/main/.github/workflows/ci.yml, which is where most of darling's workflow file comes from as far as I can tell (https://github.com/TedDriggs/darling/issues/117#issuecomment-754720411).

The `blacklisted-names = []` line in clippy.toml was added because Clippy linted the usage of `foo` in various integration test files.