### PR TITLE
Apply a series of pedantic clippy lints

### DIFF
--- a/core/src/ast/data.rs
+++ b/core/src/ast/data.rs
@@ -308,10 +308,10 @@ impl<F: FromField> Fields<F> {
             }
         };
 
-        if !errors.is_empty() {
-            Err(Error::multiple(errors))
-        } else {
+        if errors.is_empty() {
             Ok(Self::new(fields.into(), items).with_span(fields.span()))
+        } else {
+            Err(Error::multiple(errors))
         }
     }
 }

--- a/core/src/ast/data.rs
+++ b/core/src/ast/data.rs
@@ -130,10 +130,10 @@ impl<V: FromVariant, F: FromField> Data<V, F> {
                     }
                 }
 
-                if !errors.is_empty() {
-                    Err(Error::multiple(errors))
-                } else {
+                if errors.is_empty() {
                     Ok(Data::Enum(items))
+                } else {
+                    Err(Error::multiple(errors))
                 }
             }
             syn::Data::Struct(ref data) => Ok(Data::Struct(Fields::try_from(&data.fields)?)),

--- a/core/src/codegen/attr_extractor.rs
+++ b/core/src/codegen/attr_extractor.rs
@@ -25,10 +25,10 @@ pub trait ExtractAttribute {
     fn core_loop(&self) -> TokenStream;
 
     fn declarations(&self) -> TokenStream {
-        if !self.attr_names().is_empty() {
-            self.local_declarations()
-        } else {
+        if self.attr_names().is_empty() {
             self.immutable_declarations()
+        } else {
+            self.local_declarations()
         }
     }
 

--- a/core/src/codegen/from_meta_impl.rs
+++ b/core/src/codegen/from_meta_impl.rs
@@ -79,14 +79,14 @@ impl<'a> ToTokens for FromMetaImpl<'a> {
                 let unit_arms = variants.iter().map(Variant::as_unit_match_arm);
                 let struct_arms = variants.iter().map(Variant::as_data_match_arm);
 
-                let unknown_variant_err = if !variants.is_empty() {
+                let unknown_variant_err = if variants.is_empty() {
+                    quote! {
+                        unknown_field(__other)
+                    }
+                } else {
                     let names = variants.iter().map(Variant::as_name);
                     quote! {
                         unknown_field_with_alts(__other, &[#(#names),*])
-                    }
-                } else {
-                    quote! {
-                        unknown_field(__other)
                     }
                 };
 

--- a/core/src/error/kind.rs
+++ b/core/src/error/kind.rs
@@ -80,10 +80,10 @@ impl fmt::Display for ErrorKind {
                 write!(f, "Multiple errors: (")?;
                 let mut first = true;
                 for item in items {
-                    if !first {
-                        write!(f, ", ")?;
-                    } else {
+                    if first {
                         first = false;
+                    } else {
+                        write!(f, ", ")?;
                     }
 
                     item.fmt(f)?;

--- a/core/src/options/core.rs
+++ b/core/src/options/core.rs
@@ -95,13 +95,12 @@ impl ParseAttribute for Core {
             if let Some(post_transform) = &self.post_transform {
                 if transformer == post_transform.transformer {
                     return Err(Error::duplicate_field(&transformer.to_string()).with_span(mi));
-                } else {
-                    return Err(Error::custom(format!(
-                        "Options `{}` and `{}` are mutually exclusive",
-                        transformer, post_transform.transformer
-                    ))
-                    .with_span(mi));
                 }
+                return Err(Error::custom(format!(
+                    "Options `{}` and `{}` are mutually exclusive",
+                    transformer, post_transform.transformer
+                ))
+                .with_span(mi));
             }
 
             self.post_transform =

--- a/core/src/options/input_field.rs
+++ b/core/src/options/input_field.rs
@@ -147,13 +147,12 @@ impl ParseAttribute for InputField {
             if let Some(post_transform) = &self.post_transform {
                 if transformer == post_transform.transformer {
                     return Err(Error::duplicate_field_path(path).with_span(mi));
-                } else {
-                    return Err(Error::custom(format!(
-                        "Options `{}` and `{}` are mutually exclusive",
-                        transformer, post_transform.transformer
-                    ))
-                    .with_span(mi));
                 }
+                return Err(Error::custom(format!(
+                    "Options `{}` and `{}` are mutually exclusive",
+                    transformer, post_transform.transformer
+                ))
+                .with_span(mi));
             }
 
             self.post_transform = Some(codegen::PostfixTransform::new(

--- a/core/src/options/mod.rs
+++ b/core/src/options/mod.rs
@@ -66,10 +66,10 @@ pub trait ParseAttribute: Sized {
             }
         }
 
-        if !errors.is_empty() {
-            Err(Error::multiple(errors))
-        } else {
+        if errors.is_empty() {
             Ok(self)
+        } else {
+            Err(Error::multiple(errors))
         }
     }
 
@@ -89,10 +89,10 @@ fn parse_attr<T: ParseAttribute>(attr: &syn::Attribute, target: &mut T) -> Resul
                 }
             }
 
-            if !errors.is_empty() {
-                Err(Error::multiple(errors))
-            } else {
+            if errors.is_empty() {
                 Ok(())
+            } else {
+                Err(Error::multiple(errors))
             }
         }
         Some(ref item) => panic!("Wasn't able to parse: `{:?}`", item),
@@ -131,10 +131,10 @@ pub trait ParseData: Sized {
             Data::Union(_) => unreachable!(),
         };
 
-        if !errors.is_empty() {
-            Err(Error::multiple(errors))
-        } else {
+        if errors.is_empty() {
             Ok(self)
+        } else {
+            Err(Error::multiple(errors))
         }
     }
 

--- a/core/src/options/shape.rs
+++ b/core/src/options/shape.rs
@@ -175,10 +175,10 @@ impl FromMeta for DataShape {
             }
         }
 
-        if !errors.is_empty() {
-            Err(Error::multiple(errors))
-        } else {
+        if errors.is_empty() {
             Ok(new)
+        } else {
+            Err(Error::multiple(errors))
         }
     }
 }


### PR DESCRIPTION
There are three remaining ones but those suggest renaming variables and messing with structs.
They make no sense to be shipped with this batch of "re-order if branches" and "delete useless else branches"