### PR TITLE
Add Error::ok_if_empty

### DIFF
--- a/core/src/ast/data.rs
+++ b/core/src/ast/data.rs
@@ -130,11 +130,9 @@ impl<V: FromVariant, F: FromField> Data<V, F> {
                     }
                 }
 
-                if !errors.is_empty() {
-                    Err(Error::multiple(errors))
-                } else {
-                    Ok(Data::Enum(items))
-                }
+                Error::ok_if_empty(errors)?;
+
+                Ok(Data::Enum(items))
             }
             syn::Data::Struct(ref data) => Ok(Data::Struct(Fields::try_from(&data.fields)?)),
             // This deliberately doesn't set a span on the error message, as the error is most useful if
@@ -308,11 +306,9 @@ impl<F: FromField> Fields<F> {
             }
         };
 
-        if !errors.is_empty() {
-            Err(Error::multiple(errors))
-        } else {
-            Ok(Self::new(fields.into(), items).with_span(fields.span()))
-        }
+        Error::ok_if_empty(errors)?;
+
+        Ok(Self::new(fields.into(), items).with_span(fields.span()))
     }
 }
 

--- a/core/src/error/mod.rs
+++ b/core/src/error/mod.rs
@@ -214,6 +214,33 @@ impl Error {
     pub(crate) fn unknown_lit_str_value(value: &LitStr) -> Self {
         Error::unknown_value(&value.value()).with_span(value)
     }
+
+    /// Check that a list of errors is empty, or produce a single error representing
+    /// all the passed-in errors.
+    ///
+    /// # Example
+    /// ```rust,ignore
+    /// let mut errors = vec![];
+    /// let mut processed_fields = vec![];
+    ///
+    /// for field in fields {
+    ///     match fallible_operation(field) {
+    ///         Ok(v) => processed_fields.push(v),
+    ///         Err(e) => errors.push(e)
+    ///     }
+    /// }
+    ///
+    /// darling::Error::ok_if_empty(errors)?;
+    /// ```
+    pub fn ok_if_empty(mut errors: Vec<Error>) -> Result<()> {
+        match errors.len() {
+            0 => Ok(()),
+            1 => Err(errors
+                .pop()
+                .expect("Error array of length 1 has a first item")),
+            _ => Err(Error::new(ErrorKind::Multiple(errors))),
+        }
+    }
 }
 
 /// Error instance methods

--- a/core/src/from_meta.rs
+++ b/core/src/from_meta.rs
@@ -556,9 +556,7 @@ macro_rules! hash_map {
                     }
                 }
 
-                if !errors.is_empty() {
-                    return Err(Error::multiple(errors));
-                }
+                Error::ok_if_empty(errors)?;
 
                 Ok(map)
             }

--- a/core/src/options/mod.rs
+++ b/core/src/options/mod.rs
@@ -68,11 +68,8 @@ pub trait ParseAttribute: Sized {
             }
         }
 
-        if !errors.is_empty() {
-            Err(Error::multiple(errors))
-        } else {
-            Ok(self)
-        }
+        Error::ok_if_empty(errors)?;
+        Ok(self)
     }
 
     /// Read a meta-item, and apply its values to the current instance.
@@ -91,11 +88,7 @@ fn parse_attr<T: ParseAttribute>(attr: &syn::Attribute, target: &mut T) -> Resul
                 }
             }
 
-            if !errors.is_empty() {
-                Err(Error::multiple(errors))
-            } else {
-                Ok(())
-            }
+            Error::ok_if_empty(errors)
         }
         Some(ref item) => panic!("Wasn't able to parse: `{:?}`", item),
         None => panic!("Unable to parse {:?}", attr),
@@ -133,11 +126,8 @@ pub trait ParseData: Sized {
             Data::Union(_) => unreachable!(),
         };
 
-        if !errors.is_empty() {
-            Err(Error::multiple(errors))
-        } else {
-            Ok(self)
-        }
+        Error::ok_if_empty(errors)?;
+        Ok(self)
     }
 
     /// Apply the next found variant to the object, returning an error

--- a/core/src/options/shape.rs
+++ b/core/src/options/shape.rs
@@ -175,11 +175,8 @@ impl FromMeta for DataShape {
             }
         }
 
-        if !errors.is_empty() {
-            Err(Error::multiple(errors))
-        } else {
-            Ok(new)
-        }
+        Error::ok_if_empty(errors)?;
+        Ok(new)
     }
 }
 


### PR DESCRIPTION
This slightly reduces typing for the darling error-collection paradigm.

Open question: Is this worth it? I'm not convinced the code is much more readable.

Fixes #115