### PR TITLE
impl FromMeta for syn::Expr

### DIFF
--- a/core/src/from_meta.rs
+++ b/core/src/from_meta.rs
@@ -272,6 +272,19 @@ impl<T: syn::parse::Parse, P: syn::parse::Parse> FromMeta for syn::punctuated::P
     }
 }
 
+/// Parsing support for an expression, i.e. `example = "1 + 2"`.
+impl FromMeta for syn::Expr {
+    fn from_value(value: &Lit) -> Result<Self> {
+        if let Lit::Str(ref ident) = *value {
+            ident
+                .parse::<syn::Expr>()
+                .map_err(|_| Error::unknown_lit_str_value(ident))
+        } else {
+            Err(Error::unexpected_lit_type(value))
+        }
+    }
+}
+
 /// Parsing support for an array, i.e. `example = "[1 + 2, 2 - 2, 3 * 4]"`.
 impl FromMeta for syn::ExprArray {
     fn from_value(value: &Lit) -> Result<Self> {

--- a/core/src/from_meta.rs
+++ b/core/src/from_meta.rs
@@ -815,7 +815,7 @@ mod tests {
         fm::<syn::ExprArray>(quote!(ignore = "[0x1, 0x2]"));
         fm::<syn::ExprArray>(quote!(ignore = "[\"Hello World\", \"Test Array\"]"));
     }
-    
+
     #[test]
     fn test_expr() {
         fm::<syn::Expr>(quote!(ignore = "x + y"));

--- a/core/src/from_meta.rs
+++ b/core/src/from_meta.rs
@@ -815,6 +815,13 @@ mod tests {
         fm::<syn::ExprArray>(quote!(ignore = "[0x1, 0x2]"));
         fm::<syn::ExprArray>(quote!(ignore = "[\"Hello World\", \"Test Array\"]"));
     }
+    
+    #[test]
+    fn test_expr() {
+        fm::<syn::Expr>(quote!(ignore = "x + y"));
+        fm::<syn::Expr>(quote!(ignore = "an_object.method_call()"));
+        fm::<syn::Expr>(quote!(ignore = "{ a_statement(); in_a_block }"));
+    }
 
     #[test]
     fn test_number_array() {


### PR DESCRIPTION
Needed expressions in attributes, so just implemented it

Although now I see I could have just used `map`