### PR TITLE
Error collector

### DIFF
--- a/core/src/error/mod.rs
+++ b/core/src/error/mod.rs
@@ -578,7 +578,7 @@ impl Accumulator {
     fn errors(&mut self) -> &mut Vec<Error> {
         match &mut self.0 {
             Some(errors) => errors,
-            None => panic!("darling internal error"),
+            None => panic!("darling internal error: Accumulator accessed after defuse"),
         }
     }
 
@@ -589,7 +589,7 @@ impl Accumulator {
     pub fn into_inner(mut self) -> Vec<Error> {
         match std::mem::replace(&mut self.0, None) {
             Some(errors) => errors,
-            None => panic!("darling internal error"),
+            None => panic!("darling internal error: Accumulator accessed after defuse"),
         }
     }
 

--- a/core/src/error/mod.rs
+++ b/core/src/error/mod.rs
@@ -545,11 +545,13 @@ pub struct Accumulator(AccumulatorInner);
 #[derive(Debug)]
 enum AccumulatorInner {
     Live(Vec<Error>), // Drop bomb is live
-    Defused, // Exists only after passing into a public method taking owned `self`.
+    Defused,          // Exists only after passing into a public method taking owned `self`.
 }
 
 impl Default for AccumulatorInner {
-    fn default() -> Self { AccumulatorInner::Live(vec![]) }
+    fn default() -> Self {
+        AccumulatorInner::Live(vec![])
+    }
 }
 
 impl Accumulator {
@@ -573,9 +575,7 @@ impl Accumulator {
     /// on the return value from `handle` or `run`.
     pub fn handle<T>(&mut self, result: Result<T>) -> Option<T> {
         match result {
-            Ok(y) => {
-                Some(y)
-            }
+            Ok(y) => Some(y),
             Err(e) => {
                 self.push(e);
                 None
@@ -628,7 +628,7 @@ impl Accumulator {
 impl Extend<Error> for Accumulator {
     fn extend<I>(&mut self, iter: I)
     where
-        I: IntoIterator<Item = Error>
+        I: IntoIterator<Item = Error>,
     {
         self.errors().extend(iter)
     }

--- a/core/src/error/mod.rs
+++ b/core/src/error/mod.rs
@@ -525,6 +525,7 @@ impl Iterator for IntoIter {
 /// }
 /// ```
 #[derive(Default, Debug)]
+#[must_use = "you must properly finish() an Accumulator"]
 pub struct Accumulator {
     errors: Vec<Error>,
 }
@@ -575,6 +576,7 @@ impl Accumulator {
     }
 
     /// Returns the collected errors as a plain `Vec`
+    #[must_use = "the accumulated errors should not simply be dropped"]
     pub fn into_inner(self) -> Vec<Error> {
         self.errors
     }

--- a/core/src/error/mod.rs
+++ b/core/src/error/mod.rs
@@ -534,10 +534,12 @@ impl Accumulator {
     ///
     /// The closure is one which return `Result`, so inside it one can use `?`.
     pub fn run<T, F: FnOnce() -> Result<T>>(&mut self, f: F) -> Option<T> {
-        self.ok_of(f())
+        self.handle(f())
     }
 
-    /// Returns a successful value as `Some`, or collects the error and returns `None`
+    /// Handles a possible error
+    ///
+    /// Returns a successful value as `Some`, or collects the error and returns `None`.
     ///
     /// If you need an actual value `T` for further processing even in error cases,
     /// rather than a `None`,
@@ -545,8 +547,8 @@ impl Accumulator {
     /// [`Option::unwrap_or_default`],
     /// [`unwrap_or_else`](Option::unwrap_or_else) or
     /// [`unwrap_or`](Option::unwrap_or)
-    /// on the return value from `ok_of` or `run`.
-    pub fn ok_of<T>(&mut self, result: Result<T>) -> Option<T> {
+    /// on the return value from `handle` or `run`.
+    pub fn handle<T>(&mut self, result: Result<T>) -> Option<T> {
         match result {
             Ok(y) => {
                 Some(y)

--- a/core/src/error/mod.rs
+++ b/core/src/error/mod.rs
@@ -515,8 +515,8 @@ impl Iterator for IntoIter {
 ///
 ///     for thing in inputs {
 ///         let _: Option<()> = errors.run(||{
-///             let validateed = thing.validate()?;
-///             outputs.push(validateed);
+///             let validated = thing.validate()?;
+///             outputs.push(validated);
 ///             Ok(())
 ///         });
 ///     }

--- a/core/src/error/mod.rs
+++ b/core/src/error/mod.rs
@@ -47,9 +47,9 @@ pub type Result<T> = ::std::result::Result<T, Error>;
 ///    This preserves all span information, suggestions, etc. Wrapping a `darling::Error` in
 ///    a custom error enum works as-expected and does not force any loss of fidelity.
 /// 2. Do not use early return (e.g. the `?` operator) for custom validations. Instead,
-///    create a local `Vec` to collect errors as they are encountered and then use
-///    `darling::Error::multiple` to create an error containing all those issues if the list
-///    is non-empty after validation. This can create very complex custom validation functions;
+///    create an [`error::Collector`](Collector) to collect errors as they are encountered.  Then use
+///    [`Collector::conclude`] to return your validated result; it will give `Ok` iff
+///    no errors were encountered.  This can create very complex custom validation functions;
 ///    in those cases, split independent "validation chains" out into their own functions to
 ///    keep the main validator manageable.
 /// 3. Use `darling::Error::custom` to create additional errors as-needed, then call `with_span`
@@ -193,6 +193,8 @@ impl Error {
     }
 
     /// Bundle a set of multiple errors into a single `Error` instance.
+    ///
+    /// Usually it will be more convenient to use an [`error::Collector`](Collector).
     ///
     /// # Panics
     /// This function will panic if `errors.is_empty() == true`.
@@ -491,7 +493,9 @@ impl Iterator for IntoIter {
     }
 }
 
-/// Collector for errors, for helping call [`Error::multiple`]
+/// Collector for errors, for helping call [`Error::multiple`].
+///
+/// See the docs for [`darling::error::Error`](Error) for more discussion of error handling with darling.
 ///
 /// ```
 /// # extern crate darling_core as darling;

--- a/core/src/error/mod.rs
+++ b/core/src/error/mod.rs
@@ -207,6 +207,13 @@ impl Error {
             _ => Error::new(ErrorKind::Multiple(errors)),
         }
     }
+
+    /// Creates an error collector, for aggregating multiple errors
+    ///
+    /// See [`Collector`] for details.
+    pub fn collector() -> Collector {
+        Default::default()
+    }
 }
 
 impl Error {
@@ -503,7 +510,7 @@ impl Iterator for IntoIter {
 /// # struct Output;
 /// # impl Thing { fn validate(self) -> darling::Result<Output> { Ok(Output) } }
 /// fn validate_things(inputs: Vec<Thing>) -> darling::Result<Vec<Output>> {
-///     let mut errors = darling::error::Collector::new();
+///     let mut errors = darling::error::Error::collector();
 ///     let mut outputs = vec![];
 ///
 ///     for thing in inputs {
@@ -523,11 +530,6 @@ pub struct Collector {
 }
 
 impl Collector {
-    /// Creates a new empty error collector
-    pub fn new() -> Self {
-        Default::default()
-    }
-
     /// Runs a closure, returning the successful value as `Some`, or collecting the error
     ///
     /// The closure is one which return `Result`, so inside it one can use `?`.

--- a/core/src/error/mod.rs
+++ b/core/src/error/mod.rs
@@ -572,7 +572,7 @@ impl Accumulator {
         }
     }
 
-    /// Bundles the collected errors if there were any, or returns the success value
+    /// Returns the collected errors as a plain `Vec`
     pub fn into_inner(self) -> Vec<Error> {
         self.errors
     }

--- a/core/src/error/mod.rs
+++ b/core/src/error/mod.rs
@@ -581,6 +581,11 @@ impl Collector {
     pub fn push(&mut self, item: Error) {
         self.errors.push(item)
     }
+
+    /// Check if we have collected errors, and if so produce an aggregate error right away
+    pub fn checkpoint(&mut self) -> Result<()> {
+        std::mem::take(self).conclude(())
+    }
 }
 
 impl Extend<Error> for Collector {

--- a/core/src/error/mod.rs
+++ b/core/src/error/mod.rs
@@ -48,7 +48,7 @@ pub type Result<T> = ::std::result::Result<T, Error>;
 ///    a custom error enum works as-expected and does not force any loss of fidelity.
 /// 2. Do not use early return (e.g. the `?` operator) for custom validations. Instead,
 ///    create an [`error::Accumulator`](Accumulator) to collect errors as they are encountered.  Then use
-///    [`Accumulator::conclude`] to return your validated result; it will give `Ok` iff
+///    [`Accumulator::finish`] to return your validated result; it will give `Ok` iff
 ///    no errors were encountered.  This can create very complex custom validation functions;
 ///    in those cases, split independent "validation chains" out into their own functions to
 ///    keep the main validator manageable.
@@ -521,7 +521,7 @@ impl Iterator for IntoIter {
 ///         });
 ///     }
 ///
-///     errors.conclude(outputs)
+///     errors.finish(outputs)
 /// }
 /// ```
 #[derive(Default, Debug)]
@@ -564,7 +564,7 @@ impl Accumulator {
     ///
     /// If there were no errors recorded, returns `Ok(success)`.
     /// Otherwise calls [`Error::multiple`] and returns the result as an `Err`.
-    pub fn conclude<T>(self, success: T) -> Result<T> {
+    pub fn finish<T>(self, success: T) -> Result<T> {
         if self.errors.is_empty() {
             Ok(success)
         } else {
@@ -584,7 +584,7 @@ impl Accumulator {
 
     /// Check if we have collected errors, and if so produce an aggregate error right away
     pub fn checkpoint(&mut self) -> Result<()> {
-        std::mem::take(self).conclude(())
+        std::mem::take(self).finish(())
     }
 }
 

--- a/core/src/error/mod.rs
+++ b/core/src/error/mod.rs
@@ -522,7 +522,7 @@ impl Iterator for IntoIter {
 ///
 ///     let outputs = inputs
 ///         .into_iter()
-///         .filter_map(|thing| errors.run(|| thing.validate()))
+///         .filter_map(|thing| errors.handle_in(|| thing.validate()))
 ///         .collect::<Vec<_>>();
 ///
 ///     errors.finish()?;
@@ -537,7 +537,7 @@ impl Accumulator {
     /// Runs a closure, returning the successful value as `Some`, or collecting the error
     ///
     /// The closure's return type is `darling::Result`, so inside it one can use `?`.
-    pub fn run<T, F: FnOnce() -> Result<T>>(&mut self, f: F) -> Option<T> {
+    pub fn handle_in<T, F: FnOnce() -> Result<T>>(&mut self, f: F) -> Option<T> {
         self.handle(f())
     }
 

--- a/core/src/error/mod.rs
+++ b/core/src/error/mod.rs
@@ -647,7 +647,7 @@ impl Accumulator {
 
 impl Default for Accumulator {
     fn default() -> Self {
-        Self(Some(vec![]))
+        Accumulator(Some(vec![]))
     }
 }
 


### PR DESCRIPTION
I noticed the poor ergonomics of `Error::multiple`.  I see there's an issue for this already, #115.

Here is my idea of what a nice API woudl be like.  It handles not only the awkward `if errors.is_empty()` at the end, but also collection of errors as we go.  This is IMO a better alternative to #155.