### PR TITLE
fix: small error of consume_fields.rs in examples

### DIFF
--- a/examples/consume_fields.rs
+++ b/examples/consume_fields.rs
@@ -117,7 +117,7 @@ impl ToTokens for MyInputReceiver {
         tokens.extend(quote! {
             impl #imp Speak for #ident #ty #wher {
                 fn speak(&self, writer: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-                    write!(#fmt_string, #(#field_list),*)
+                    write!(writer, #fmt_string, #(#field_list),*)
                 }
             }
         });


### PR DESCRIPTION
Hi, 

I was learning `darling` and found a small code error in consume_fields.rs in examples.

The `write!` macro needs to pass the corresponding Formatter instance writer as an argument.

PS: I found this when I implemented similar code locally~ 