### PR TITLE
Internally adopt error::Accumulator (not in codegen)

### DIFF
--- a/core/src/ast/data.rs
+++ b/core/src/ast/data.rs
@@ -121,20 +121,14 @@ impl<V: FromVariant, F: FromField> Data<V, F> {
     pub fn try_from(body: &syn::Data) -> Result<Self> {
         match *body {
             syn::Data::Enum(ref data) => {
-                let mut items = Vec::with_capacity(data.variants.len());
-                let mut errors = Vec::new();
-                for v_result in data.variants.iter().map(FromVariant::from_variant) {
-                    match v_result {
-                        Ok(val) => items.push(val),
-                        Err(err) => errors.push(err),
-                    }
-                }
+                let mut errors = Error::accumulator();
+                let items = data
+                    .variants
+                    .iter()
+                    .filter_map(|v| errors.handle(FromVariant::from_variant(v)))
+                    .collect();
 
-                if !errors.is_empty() {
-                    Err(Error::multiple(errors))
-                } else {
-                    Ok(Data::Enum(items))
-                }
+                errors.finish_with(Data::Enum(items))
             }
             syn::Data::Struct(ref data) => Ok(Data::Struct(Fields::try_from(&data.fields)?)),
             // This deliberately doesn't set a span on the error message, as the error is most useful if
@@ -264,55 +258,37 @@ impl<T> Fields<T> {
 
 impl<F: FromField> Fields<F> {
     pub fn try_from(fields: &syn::Fields) -> Result<Self> {
-        let (items, errors) = {
+        let mut errors = Error::accumulator();
+        let items = {
             match &fields {
-                syn::Fields::Named(fields) => {
-                    let mut items = Vec::with_capacity(fields.named.len());
-                    let mut errors = Vec::new();
-
-                    for field in &fields.named {
-                        match FromField::from_field(field) {
-                            Ok(val) => items.push(val),
-                            Err(err) => errors.push({
-                                if let Some(ident) = &field.ident {
-                                    err.at(ident)
-                                } else {
-                                    err
-                                }
-                            }),
-                        }
-                    }
-
-                    (items, errors)
-                }
-                syn::Fields::Unnamed(fields) => {
-                    let mut items = Vec::with_capacity(fields.unnamed.len());
-                    let mut errors = Vec::new();
-
-                    for field in &fields.unnamed {
-                        match FromField::from_field(field) {
-                            Ok(val) => items.push(val),
-                            Err(err) => errors.push({
-                                if let Some(ident) = &field.ident {
-                                    err.at(ident)
-                                } else {
-                                    err
-                                }
-                            }),
-                        }
-                    }
-
-                    (items, errors)
-                }
-                syn::Fields::Unit => (vec![], vec![]),
+                syn::Fields::Named(fields) => fields
+                    .named
+                    .iter()
+                    .filter_map(|field| {
+                        errors.handle(FromField::from_field(field).map_err(|err| {
+                            // There should always be an ident here, since this is a collection
+                            // of named fields, but `syn` doesn't prevent someone from manually
+                            // constructing an invalid collection so a guard is still warranted.
+                            if let Some(ident) = &field.ident {
+                                err.at(ident)
+                            } else {
+                                err
+                            }
+                        }))
+                    })
+                    .collect(),
+                syn::Fields::Unnamed(fields) => fields
+                    .unnamed
+                    .iter()
+                    .filter_map(|field| errors.handle(FromField::from_field(field)))
+                    .collect(),
+                syn::Fields::Unit => vec![],
             }
         };
 
-        if !errors.is_empty() {
-            Err(Error::multiple(errors))
-        } else {
-            Ok(Self::new(fields.into(), items).with_span(fields.span()))
-        }
+        errors.finish()?;
+
+        Ok(Self::new(fields.into(), items).with_span(fields.span()))
     }
 }
 

--- a/core/src/options/shape.rs
+++ b/core/src/options/shape.rs
@@ -162,24 +162,18 @@ impl DataShape {
 
 impl FromMeta for DataShape {
     fn from_list(items: &[NestedMeta]) -> Result<Self> {
-        let mut errors = Vec::new();
+        let mut errors = Error::accumulator();
         let mut new = DataShape::default();
 
         for item in items {
             if let NestedMeta::Meta(Meta::Path(ref path)) = *item {
-                if let Err(e) = new.set_word(&path.segments.first().unwrap().ident.to_string()) {
-                    errors.push(e.with_span(&path));
-                }
+                errors.handle(new.set_word(&path.segments.first().unwrap().ident.to_string()));
             } else {
                 errors.push(Error::unsupported_format("non-word").with_span(item));
             }
         }
 
-        if !errors.is_empty() {
-            Err(Error::multiple(errors))
-        } else {
-            Ok(new)
-        }
+        errors.finish_with(new)
     }
 }
 


### PR DESCRIPTION
This switches all the cases where `darling` manually used the error vec over to use `Accumulator`.

@ijackson check it out