### PR TITLE
Bump min versions of quote, syn, and proc-macro2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,9 @@ darling_core = { version = "=0.13.4", path = "core" }
 darling_macro = { version = "=0.13.4", path = "macro" }
 
 [dev-dependencies]
-proc-macro2 = "1.0.26"
-quote = "1.0.9"
-syn = "1.0.69"
+proc-macro2 = "1.0.37"
+quote = "1.0.18"
+syn = "1.0.91"
 
 [features]
 default = ["suggestions"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -16,8 +16,8 @@ suggestions = ["strsim"]
 
 [dependencies]
 ident_case = "1.0.1"
-proc-macro2 = "1.0.26"
-quote = "1.0.9"
-syn = { version = "1.0.69", features = ["full", "extra-traits"] }
+proc-macro2 = "1.0.37"
+quote = "1.0.18"
+syn = { version = "1.0.91", features = ["full", "extra-traits"] }
 fnv = "1.0.7"
 strsim = { version = "0.10.0", optional = true }

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -11,8 +11,8 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
-quote = "1.0.9"
-syn = "1.0.69"
+quote = "1.0.18"
+syn = "1.0.91"
 darling_core = { version = "=0.13.4", path = "../core" }
 
 [lib]


### PR DESCRIPTION
This ensures we get the performance gains of quote 1.0.18