### PR TITLE
Error methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 - Fix a bug where using a trait that accepts `#[darling(attributes(...))]` without specifying any attributes would emit code that did not compile. [#183](https://github.com/TedDriggs/darling/issues/183)
+- Impl `Clone` for `darling::Error` [#184](https://github.com/TedDriggs/darling/pull/184)
+- Impl `From<darling::Error> for syn::Error` [#184](https://github.com/TedDriggs/darling/pull/184)
+- Add `Error::span` and `Error::explicit_span` methods [#184](https://github.com/TedDriggs/darling/pull/184)
 
 ## v0.14.0 (April 13, 2022)
 

--- a/core/src/error/kind.rs
+++ b/core/src/error/kind.rs
@@ -6,10 +6,10 @@ type DeriveInputShape = String;
 type FieldName = String;
 type MetaFormat = String;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 // Don't want to publicly commit to ErrorKind supporting equality yet, but
 // not having it makes testing very difficult.
-#[cfg_attr(test, derive(Clone, PartialEq, Eq))]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub(in crate::error) enum ErrorKind {
     /// An arbitrary error message.
     Custom(String),
@@ -104,10 +104,10 @@ impl From<ErrorUnknownField> for ErrorKind {
 
 /// An error for an unknown field, with a possible "did-you-mean" suggestion to get
 /// the user back on the right track.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 // Don't want to publicly commit to ErrorKind supporting equality yet, but
 // not having it makes testing very difficult.
-#[cfg_attr(test, derive(Clone, PartialEq, Eq))]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub(in crate::error) struct ErrorUnknownField {
     name: String,
     did_you_mean: Option<String>,

--- a/core/src/error/mod.rs
+++ b/core/src/error/mod.rs
@@ -252,6 +252,20 @@ impl Error {
         self
     }
 
+    /// Get a span for the error.
+    ///
+    /// # Return Value
+    /// This function will return [`Span::call_site()`](proc_macro2::Span) if [`Self::has_span`] is `false`.
+    /// To get the span only if one has been explicitly set for `self`, instead use [`Error::explicit_span`].
+    pub fn span(&self) -> Span {
+        self.span.unwrap_or_else(Span::call_site)
+    }
+
+    /// Get the span for `self`, if one has been set.
+    pub fn explicit_span(&self) -> Option<Span> {
+        self.span
+    }
+
     /// Recursively converts a tree of errors to a flattened list.
     pub fn flatten(self) -> Self {
         Error::multiple(self.into_vec())


### PR DESCRIPTION
* Add `Error::span` and `Error::explicit_span`
* `impl From<Error> for syn::Error`
* Derive `Clone` for `Error`