### PR TITLE
Always declare locals as mutable in derived impls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix a bug where using a trait that accepts `#[darling(attributes(...))]` without specifying any attributes would emit code that did not compile. [#183](https://github.com/TedDriggs/darling/issues/183)
+
 ## v0.14.0 (April 13, 2022)
 
 - **BREAKING CHANGE:** Remove many trait impls from `util::Flag`. 

--- a/core/src/codegen/attr_extractor.rs
+++ b/core/src/codegen/attr_extractor.rs
@@ -8,11 +8,6 @@ pub trait ExtractAttribute {
     /// A set of mutable declarations for all members of the implementing type.
     fn local_declarations(&self) -> TokenStream;
 
-    /// A set of immutable declarations for all members of the implementing type.
-    /// This is used in the case where a deriving struct handles no attributes and therefore can
-    /// never change its default state.
-    fn immutable_declarations(&self) -> TokenStream;
-
     /// Gets the list of attribute names that should be parsed by the extractor.
     fn attr_names(&self) -> &PathList;
 
@@ -32,17 +27,9 @@ pub trait ExtractAttribute {
     /// Gets the core from-meta-item loop that should be used on matching attributes.
     fn core_loop(&self) -> TokenStream;
 
-    fn declarations(&self) -> TokenStream {
-        if !self.attr_names().is_empty() {
-            self.local_declarations()
-        } else {
-            self.immutable_declarations()
-        }
-    }
-
     /// Generates the main extraction loop.
     fn extractor(&self) -> TokenStream {
-        let declarations = self.declarations();
+        let declarations = self.local_declarations();
 
         let will_parse_any = !self.attr_names().is_empty();
         let will_fwd_any = self

--- a/core/src/codegen/field.rs
+++ b/core/src/codegen/field.rs
@@ -34,7 +34,7 @@ impl<'a> Field<'a> {
     }
 
     pub fn as_declaration(&'a self) -> Declaration<'a> {
-        Declaration(self, !self.skip)
+        Declaration(self)
     }
 
     pub fn as_match(&'a self) -> MatchArm<'a> {
@@ -61,14 +61,7 @@ impl<'a> UsesTypeParams for Field<'a> {
 }
 
 /// An individual field during variable declaration in the generated parsing method.
-pub struct Declaration<'a>(&'a Field<'a>, bool);
-
-impl<'a> Declaration<'a> {
-    /// Creates a new declaration with the given field and mutability.
-    pub fn new(field: &'a Field<'a>, mutable: bool) -> Self {
-        Declaration(field, mutable)
-    }
-}
+pub struct Declaration<'a>(&'a Field<'a>);
 
 impl<'a> ToTokens for Declaration<'a> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
@@ -76,13 +69,11 @@ impl<'a> ToTokens for Declaration<'a> {
         let ident = field.ident;
         let ty = field.ty;
 
-        let mutable = if self.1 { quote!(mut) } else { quote!() };
-
         tokens.append_all(if field.multiple {
             // This is NOT mutable, as it will be declared mutable only temporarily.
-            quote!(let #mutable #ident: #ty = ::darling::export::Default::default();)
+            quote!(let mut #ident: #ty = ::darling::export::Default::default();)
         } else {
-            quote!(let #mutable #ident: (bool, ::darling::export::Option<#ty>) = (false, None);)
+            quote!(let mut #ident: (bool, ::darling::export::Option<#ty>) = (false, None);)
         });
     }
 }

--- a/core/src/codegen/from_attributes_impl.rs
+++ b/core/src/codegen/from_attributes_impl.rs
@@ -73,10 +73,6 @@ impl<'a> ExtractAttribute for FromAttributesImpl<'a> {
         self.base.local_declarations()
     }
 
-    fn immutable_declarations(&self) -> TokenStream {
-        self.base.immutable_declarations()
-    }
-
     fn attr_names(&self) -> &PathList {
         self.attr_names
     }

--- a/core/src/codegen/from_derive_impl.rs
+++ b/core/src/codegen/from_derive_impl.rs
@@ -130,10 +130,6 @@ impl<'a> ExtractAttribute for FromDeriveInputImpl<'a> {
     fn local_declarations(&self) -> TokenStream {
         self.base.local_declarations()
     }
-
-    fn immutable_declarations(&self) -> TokenStream {
-        self.base.immutable_declarations()
-    }
 }
 
 impl<'a> OuterFromImpl<'a> for FromDeriveInputImpl<'a> {

--- a/core/src/codegen/from_field.rs
+++ b/core/src/codegen/from_field.rs
@@ -97,10 +97,6 @@ impl<'a> ExtractAttribute for FromFieldImpl<'a> {
     fn local_declarations(&self) -> TokenStream {
         self.base.local_declarations()
     }
-
-    fn immutable_declarations(&self) -> TokenStream {
-        self.base.immutable_declarations()
-    }
 }
 
 impl<'a> OuterFromImpl<'a> for FromFieldImpl<'a> {

--- a/core/src/codegen/from_type_param.rs
+++ b/core/src/codegen/from_type_param.rs
@@ -96,10 +96,6 @@ impl<'a> ExtractAttribute for FromTypeParamImpl<'a> {
     fn local_declarations(&self) -> TokenStream {
         self.base.local_declarations()
     }
-
-    fn immutable_declarations(&self) -> TokenStream {
-        self.base.immutable_declarations()
-    }
 }
 
 impl<'a> OuterFromImpl<'a> for FromTypeParamImpl<'a> {

--- a/core/src/codegen/from_variant_impl.rs
+++ b/core/src/codegen/from_variant_impl.rs
@@ -108,10 +108,6 @@ impl<'a> ExtractAttribute for FromVariantImpl<'a> {
         self.base.local_declarations()
     }
 
-    fn immutable_declarations(&self) -> TokenStream {
-        self.base.immutable_declarations()
-    }
-
     fn attr_names(&self) -> &PathList {
         self.attr_names
     }

--- a/core/src/codegen/trait_impl.rs
+++ b/core/src/codegen/trait_impl.rs
@@ -4,7 +4,7 @@ use syn::{Generics, Ident, WherePredicate};
 use crate::ast::{Data, Fields};
 use crate::codegen::{
     error::{ErrorCheck, ErrorDeclaration},
-    field, DefaultExpression, Field, FieldsGen, PostfixTransform, Variant,
+    DefaultExpression, Field, FieldsGen, PostfixTransform, Variant,
 };
 use crate::usage::{CollectTypeParams, IdentSet, Purpose};
 
@@ -90,17 +90,6 @@ impl<'a> TraitImpl<'a> {
     pub(in crate::codegen) fn local_declarations(&self) -> TokenStream {
         if let Data::Struct(ref vd) = self.data {
             let vdr = vd.as_ref().map(Field::as_declaration);
-            let decls = vdr.fields.as_slice();
-            quote!(#(#decls)*)
-        } else {
-            quote!()
-        }
-    }
-
-    /// Generate immutable variable declarations for all fields.
-    pub(in crate::codegen) fn immutable_declarations(&self) -> TokenStream {
-        if let Data::Struct(ref vd) = self.data {
-            let vdr = vd.as_ref().map(|f| field::Declaration::new(f, false));
             let decls = vdr.fields.as_slice();
             quote!(#(#decls)*)
         } else {

--- a/tests/skip.rs
+++ b/tests/skip.rs
@@ -44,3 +44,31 @@ fn verify_skipped_field_not_required() {
         }
     );
 }
+
+/// This test verifies that a skipped field will still prefer an explicit default
+/// over the default that would come from its field type. It would be incorrect for
+/// `Defaulting::from_derive_input` to fail here, and it would be wrong for the value
+/// of `dolor` to be `None`.
+#[test]
+fn verify_default_supersedes_from_none() {
+    fn default_dolor() -> Option<u8> {
+        Some(2)
+    }
+
+    #[derive(Debug, PartialEq, Eq, FromDeriveInput)]
+    #[darling(attributes(skip_test))]
+    pub struct Defaulting {
+        #[darling(skip, default = "default_dolor")]
+        dolor: Option<u8>,
+    }
+
+    let di = parse_quote! {
+        #[skip_test]
+        struct Baz;
+    };
+
+    assert_eq!(
+        Defaulting::from_derive_input(&di).unwrap(),
+        Defaulting { dolor: Some(2) }
+    )
+}


### PR DESCRIPTION
Values for fields are kept in local variables prior to construction in
the `From*` derivations. Before #177, these local variables would be
immutable, since nothing would ever modify them. However, now the
generated code will mutate the local variable to insert the result of
a `from_none` call to the child. Therefore, for simplicity the variables
are always emitted as mutable.

Fixes #183