### PR TITLE
Error when parsing FromMeta containing NestedMeta::Lit

### DIFF
--- a/core/src/codegen/variant_data.rs
+++ b/core/src/codegen/variant_data.rs
@@ -64,6 +64,8 @@ impl<'a> FieldsGen<'a> {
                         #(#arms)*
                         __other => { #handle_unknown }
                     }
+                } else {
+                    __errors.push(::darling::Error::unsupported_format("literal").with_span(__item));
                 }
             }
         )

--- a/core/src/codegen/variant_data.rs
+++ b/core/src/codegen/variant_data.rs
@@ -66,8 +66,9 @@ impl<'a> FieldsGen<'a> {
                             __other => { #handle_unknown }
                         }
                     }
-                    ::syn::NestedMeta::Lit(_) => {
-                        __errors.push(::darling::Error::unsupported_format("literal").with_span(__item));
+                    ::syn::NestedMeta::Lit(ref __inner) => {
+                        __errors.push(::darling::Error::unsupported_format("literal")
+                            .with_span(__inner));
                     }
                 }
             }

--- a/core/src/codegen/variant_data.rs
+++ b/core/src/codegen/variant_data.rs
@@ -58,14 +58,17 @@ impl<'a> FieldsGen<'a> {
 
         quote!(
             for __item in __items {
-                if let ::syn::NestedMeta::Meta(ref __inner) = *__item {
-                    let __name = ::darling::util::path_to_string(__inner.path());
-                    match __name.as_str() {
-                        #(#arms)*
-                        __other => { #handle_unknown }
+                match *__item {
+                    ::syn::NestedMeta::Meta(ref __inner) => {
+                        let __name = ::darling::util::path_to_string(__inner.path());
+                        match __name.as_str() {
+                            #(#arms)*
+                            __other => { #handle_unknown }
+                        }
                     }
-                } else {
-                    __errors.push(::darling::Error::unsupported_format("literal").with_span(__item));
+                    ::syn::NestedMeta::Lit(_) => {
+                        __errors.push(::darling::Error::unsupported_format("literal").with_span(__item));
+                    }
                 }
             }
         )

--- a/tests/from_meta.rs
+++ b/tests/from_meta.rs
@@ -1,0 +1,40 @@
+use darling::FromMeta;
+use syn::parse_quote;
+
+#[derive(FromMeta)]
+struct Meta {
+    #[darling(default)]
+    meta1: Option<String>,
+    #[darling(default)]
+    meta2: bool,
+}
+
+#[test]
+fn nested_meta_meta_value() {
+    let meta = Meta::from_list(&vec![parse_quote! {
+        meta1 = "thefeature"
+    }])
+    .unwrap();
+    assert_eq!(meta.meta1, Some("thefeature".to_string()));
+    assert_eq!(meta.meta2, false);
+}
+
+#[test]
+fn nested_meta_meta_bool() {
+    let meta = Meta::from_list(&vec![parse_quote! {
+        meta2
+    }])
+    .unwrap();
+    assert_eq!(meta.meta1, None);
+    assert_eq!(meta.meta2, true);
+}
+
+#[test]
+fn nested_meta_lit_errors() {
+    let meta = Meta::from_list(&vec![parse_quote! {
+        "meta2"
+    }])
+    .unwrap();
+    assert_eq!(meta.meta1, None);
+    assert_eq!(meta.meta2, false);
+}

--- a/tests/from_meta.rs
+++ b/tests/from_meta.rs
@@ -35,5 +35,8 @@ fn nested_meta_lit_errors() {
         "meta2"
     }])
     .unwrap_err();
-    assert_eq!(err.to_string(), Error::unsupported_format("literal").to_string());
+    assert_eq!(
+        err.to_string(),
+        Error::unsupported_format("literal").to_string()
+    );
 }

--- a/tests/from_meta.rs
+++ b/tests/from_meta.rs
@@ -1,7 +1,7 @@
-use darling::FromMeta;
+use darling::{Error, FromMeta};
 use syn::parse_quote;
 
-#[derive(FromMeta)]
+#[derive(Debug, FromMeta)]
 struct Meta {
     #[darling(default)]
     meta1: Option<String>,
@@ -31,10 +31,9 @@ fn nested_meta_meta_bool() {
 
 #[test]
 fn nested_meta_lit_errors() {
-    let meta = Meta::from_list(&vec![parse_quote! {
+    let err = Meta::from_list(&vec![parse_quote! {
         "meta2"
     }])
-    .unwrap();
-    assert_eq!(meta.meta1, None);
-    assert_eq!(meta.meta2, false);
+    .unwrap_err();
+    assert_eq!(err.to_string(), Error::unknown_value("meta2").to_string());
 }

--- a/tests/from_meta.rs
+++ b/tests/from_meta.rs
@@ -30,9 +30,33 @@ fn nested_meta_meta_bool() {
 }
 
 #[test]
-fn nested_meta_lit_errors() {
+fn nested_meta_lit_string_errors() {
     let err = Meta::from_list(&vec![parse_quote! {
         "meta2"
+    }])
+    .unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        Error::unsupported_format("literal").to_string()
+    );
+}
+
+#[test]
+fn nested_meta_lit_integer_errors() {
+    let err = Meta::from_list(&vec![parse_quote! {
+        2
+    }])
+    .unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        Error::unsupported_format("literal").to_string()
+    );
+}
+
+#[test]
+fn nested_meta_lit_bool_errors() {
+    let err = Meta::from_list(&vec![parse_quote! {
+        true
     }])
     .unwrap_err();
     assert_eq!(

--- a/tests/from_meta.rs
+++ b/tests/from_meta.rs
@@ -35,5 +35,5 @@ fn nested_meta_lit_errors() {
         "meta2"
     }])
     .unwrap_err();
-    assert_eq!(err.to_string(), Error::unknown_value("meta2").to_string());
+    assert_eq!(err.to_string(), Error::unsupported_format("literal").to_string());
 }


### PR DESCRIPTION
### What
Generate an error when parsing derived `FromMeta` implementations that contain a `NestedMeta::Lit`.

### Why
Literal values are unsupported in the code generated by `FromMeta`. Literal values, like strings, get ignored by the parse implementation that gets generated with the FromMeta generated code. This is confusing to a user since it appears like the value is being accepted and used in some way. We should error when the user provides a literal since the derived code will do nothing with it.

Fix #192