### PR TITLE
Don't require `FromMeta` for field types, if the field is transformed

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,7 @@ pub use darling_core::ToTokens;
 pub mod export {
     pub use core::convert::From;
     pub use core::default::Default;
+    pub use core::ops::FnOnce;
     pub use core::option::Option::{self, None, Some};
     pub use core::result::Result::{self, Err, Ok};
     pub use std::string::ToString;

--- a/tests/non_from_meta_implementation.rs
+++ b/tests/non_from_meta_implementation.rs
@@ -1,0 +1,48 @@
+//! `and_then` and `map` should remote the requirement to implement `FromMeta`
+#![allow(dead_code)]
+
+use darling::{FromDeriveInput, Result};
+use syn::parse_quote;
+
+#[derive(Debug)]
+struct DoesNotImplFromMeta;
+
+#[derive(Debug, FromDeriveInput)]
+#[darling(attributes(hello))]
+struct Foo {
+    #[darling(map = "map_fn")]
+    map: DoesNotImplFromMeta,
+    #[darling(and_then = "and_then_fn")]
+    and_then: DoesNotImplFromMeta,
+    #[darling(map = "opt_map_fn")]
+    opt_map: Option<DoesNotImplFromMeta>,
+    #[darling(and_then = "opt_and_then_fn")]
+    opt_and_then: Option<DoesNotImplFromMeta>,
+}
+
+fn map_fn(_: syn::Lit) -> DoesNotImplFromMeta {
+    DoesNotImplFromMeta
+}
+
+fn and_then_fn(_: syn::Expr) -> Result<DoesNotImplFromMeta> {
+    Ok(DoesNotImplFromMeta)
+}
+
+fn opt_map_fn(opt: Option<syn::Ident>) -> Option<DoesNotImplFromMeta> {
+    opt.map(|_| DoesNotImplFromMeta)
+}
+
+fn opt_and_then_fn(opt: Option<syn::Path>) -> Result<Option<DoesNotImplFromMeta>> {
+    Ok(opt.map(|_| DoesNotImplFromMeta))
+}
+
+#[test]
+fn expansion() {
+    let di = parse_quote! {
+        #[hello(map = false, and_then = "42")]
+        #[hello(opt_map = "foo")]
+        pub struct Foo;
+    };
+
+    Foo::from_derive_input(&di).unwrap();
+}


### PR DESCRIPTION
Maybe there's already a way of doing that, that I missed.

If a field is transformed using `map` or `and_then` it would be nice if there's no `FromMeta` bound on the field type, but only on the argument type of the transform function.

This is not totally straightforward, since it's not yet possible to directly name the argument/return type of a function. But it's possible using a dedicated function and type inference.

I'm not sure if this fits the coding style of the rest of the repo. I'm happy to change it.
The code is formatted using `rustfmt 1.5.1-nightly (215e3cd 2022-11-03)`.