### PR TITLE
Get rid of extern-crate declarations

### DIFF
--- a/core/src/ast/data.rs
+++ b/core/src/ast/data.rs
@@ -1,7 +1,7 @@
 use std::{slice, vec};
 
 use proc_macro2::{Span, TokenStream};
-use quote::ToTokens;
+use quote::{quote, quote_spanned, ToTokens};
 use syn::spanned::Spanned;
 
 use crate::usage::{

--- a/core/src/ast/generics.rs
+++ b/core/src/ast/generics.rs
@@ -177,6 +177,8 @@ impl<'a, P: GenericParamExt> Iterator for TypeParams<'a, P> {
 
 #[cfg(test)]
 mod tests {
+    use syn::parse_quote;
+
     use super::{GenericParam, Generics};
     use crate::FromGenerics;
 

--- a/core/src/codegen/attr_extractor.rs
+++ b/core/src/codegen/attr_extractor.rs
@@ -1,4 +1,5 @@
 use proc_macro2::TokenStream;
+use quote::quote;
 
 use crate::options::ForwardAttrs;
 use crate::util::PathList;

--- a/core/src/codegen/default_expr.rs
+++ b/core/src/codegen/default_expr.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream;
-use quote::{ToTokens, TokenStreamExt};
+use quote::{quote, ToTokens, TokenStreamExt};
 use syn::{Ident, Path};
 
 /// This will be in scope during struct initialization after option parsing.

--- a/core/src/codegen/error.rs
+++ b/core/src/codegen/error.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream;
-use quote::{ToTokens, TokenStreamExt};
+use quote::{quote, ToTokens, TokenStreamExt};
 
 /// Declares the local variable into which errors will be accumulated.
 #[derive(Default)]

--- a/core/src/codegen/field.rs
+++ b/core/src/codegen/field.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use proc_macro2::TokenStream;
-use quote::{ToTokens, TokenStreamExt};
+use quote::{quote, ToTokens, TokenStreamExt};
 use syn::{Ident, Path, Type};
 
 use crate::codegen::{DefaultExpression, PostfixTransform};

--- a/core/src/codegen/from_attributes_impl.rs
+++ b/core/src/codegen/from_attributes_impl.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream;
-use quote::ToTokens;
+use quote::{quote, ToTokens};
 
 use crate::{
     ast::Data,

--- a/core/src/codegen/from_derive_impl.rs
+++ b/core/src/codegen/from_derive_impl.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream;
-use quote::ToTokens;
+use quote::{quote, ToTokens};
 use syn::Ident;
 
 use crate::{

--- a/core/src/codegen/from_field.rs
+++ b/core/src/codegen/from_field.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream;
-use quote::ToTokens;
+use quote::{quote, ToTokens};
 use syn::Ident;
 
 use crate::{

--- a/core/src/codegen/from_meta_impl.rs
+++ b/core/src/codegen/from_meta_impl.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream;
-use quote::ToTokens;
+use quote::{quote, ToTokens};
 
 use crate::ast::{Data, Fields, Style};
 use crate::codegen::{Field, OuterFromImpl, TraitImpl, Variant};

--- a/core/src/codegen/from_type_param.rs
+++ b/core/src/codegen/from_type_param.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream;
-use quote::ToTokens;
+use quote::{quote, ToTokens};
 use syn::Ident;
 
 use crate::codegen::{ExtractAttribute, OuterFromImpl, TraitImpl};

--- a/core/src/codegen/from_variant_impl.rs
+++ b/core/src/codegen/from_variant_impl.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream;
-use quote::ToTokens;
+use quote::{quote, ToTokens};
 use syn::Ident;
 
 use crate::codegen::{ExtractAttribute, OuterFromImpl, TraitImpl};

--- a/core/src/codegen/outer_from_impl.rs
+++ b/core/src/codegen/outer_from_impl.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream;
-use quote::{ToTokens, TokenStreamExt};
+use quote::{quote, ToTokens, TokenStreamExt};
 use syn::{GenericParam, Generics, Path, TraitBound, TraitBoundModifier, TypeParamBound};
 
 use crate::codegen::TraitImpl;

--- a/core/src/codegen/postfix_transform.rs
+++ b/core/src/codegen/postfix_transform.rs
@@ -1,4 +1,4 @@
-use quote::{ToTokens, TokenStreamExt};
+use quote::{quote, ToTokens, TokenStreamExt};
 use syn::{Ident, Path};
 
 /// A method invocation applied to a value.

--- a/core/src/codegen/trait_impl.rs
+++ b/core/src/codegen/trait_impl.rs
@@ -1,4 +1,5 @@
 use proc_macro2::TokenStream;
+use quote::quote;
 use syn::{Generics, Ident, WherePredicate};
 
 use crate::ast::{Data, Fields};

--- a/core/src/codegen/variant.rs
+++ b/core/src/codegen/variant.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use proc_macro2::TokenStream;
-use quote::{ToTokens, TokenStreamExt};
+use quote::{quote, ToTokens, TokenStreamExt};
 use syn::Ident;
 
 use crate::ast::Fields;

--- a/core/src/codegen/variant_data.rs
+++ b/core/src/codegen/variant_data.rs
@@ -1,4 +1,5 @@
 use proc_macro2::TokenStream;
+use quote::quote;
 
 use crate::ast::{Fields, Style};
 use crate::codegen::Field;

--- a/core/src/error/mod.rs
+++ b/core/src/error/mod.rs
@@ -344,7 +344,7 @@ impl Error {
         #[cfg(feature = "diagnostics")]
         {
             self.emit();
-            quote!()
+            TokenStream::default()
         }
 
         #[cfg(not(feature = "diagnostics"))]

--- a/core/src/from_meta.rs
+++ b/core/src/from_meta.rs
@@ -605,6 +605,7 @@ hash_map!(syn::Path);
 #[cfg(test)]
 mod tests {
     use proc_macro2::TokenStream;
+    use quote::quote;
     use syn::parse_quote;
 
     use crate::{Error, FromMeta, Result};

--- a/core/src/from_meta.rs
+++ b/core/src/from_meta.rs
@@ -605,6 +605,7 @@ hash_map!(syn::Path);
 #[cfg(test)]
 mod tests {
     use proc_macro2::TokenStream;
+    use syn::parse_quote;
 
     use crate::{Error, FromMeta, Result};
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,8 +1,6 @@
 #![recursion_limit = "256"]
 #![cfg_attr(feature = "diagnostics", feature(proc_macro_diagnostic))]
 
-#[macro_use]
-extern crate quote;
 #[cfg(feature = "diagnostics")]
 extern crate proc_macro;
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -3,8 +3,6 @@
 
 #[macro_use]
 extern crate quote;
-#[macro_use]
-extern crate syn;
 extern crate fnv;
 extern crate ident_case;
 #[cfg(feature = "diagnostics")]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -3,13 +3,8 @@
 
 #[macro_use]
 extern crate quote;
-extern crate fnv;
-extern crate ident_case;
 #[cfg(feature = "diagnostics")]
 extern crate proc_macro;
-extern crate proc_macro2;
-#[cfg(feature = "suggestions")]
-extern crate strsim;
 
 #[macro_use]
 mod macros_private;

--- a/core/src/macros_private.rs
+++ b/core/src/macros_private.rs
@@ -1,9 +1,3 @@
-macro_rules! quote {
-    ($($tt:tt)*) => {
-        quote_spanned!(::proc_macro2::Span::call_site() => $($tt)*)
-    };
-}
-
 macro_rules! path {
     ($($path:tt)+) => {
         ::syn::parse_quote!($($path)+)

--- a/core/src/macros_private.rs
+++ b/core/src/macros_private.rs
@@ -6,7 +6,7 @@ macro_rules! quote {
 
 macro_rules! path {
     ($($path:tt)+) => {
-        parse_quote!($($path)+)
+        ::syn::parse_quote!($($path)+)
         //stringify!($($path)+).parse().unwrap()
     };
 }

--- a/core/src/options/input_field.rs
+++ b/core/src/options/input_field.rs
@@ -1,5 +1,7 @@
 use std::borrow::Cow;
 
+use syn::parse_quote;
+
 use crate::codegen;
 use crate::options::{Core, DefaultExpression, ParseAttribute};
 use crate::{Error, FromMeta, Result};

--- a/core/src/options/mod.rs
+++ b/core/src/options/mod.rs
@@ -1,3 +1,5 @@
+use syn::parse_quote;
+
 use crate::{Error, FromMeta, Result};
 
 mod core;

--- a/core/src/options/shape.rs
+++ b/core/src/options/shape.rs
@@ -2,7 +2,7 @@
 //! that they only work on - for example - structs with named fields, or newtype enum variants.
 
 use proc_macro2::TokenStream;
-use quote::{ToTokens, TokenStreamExt};
+use quote::{quote, ToTokens, TokenStreamExt};
 use syn::{Meta, NestedMeta};
 
 use crate::{Error, FromMeta, Result};
@@ -232,6 +232,7 @@ fn match_arm(name: &'static str, is_supported: bool) -> TokenStream {
 #[cfg(test)]
 mod tests {
     use proc_macro2::TokenStream;
+    use quote::quote;
     use syn::parse_quote;
 
     use super::Shape;

--- a/core/src/options/shape.rs
+++ b/core/src/options/shape.rs
@@ -232,6 +232,7 @@ fn match_arm(name: &'static str, is_supported: bool) -> TokenStream {
 #[cfg(test)]
 mod tests {
     use proc_macro2::TokenStream;
+    use syn::parse_quote;
 
     use super::Shape;
     use crate::FromMeta;

--- a/core/src/usage/lifetimes.rs
+++ b/core/src/usage/lifetimes.rs
@@ -282,6 +282,7 @@ impl UsesLifetimes for syn::TypeParamBound {
 #[cfg(test)]
 mod tests {
     use proc_macro2::Span;
+    use syn::parse_quote;
     use syn::DeriveInput;
 
     use super::UsesLifetimes;

--- a/core/src/usage/type_params.rs
+++ b/core/src/usage/type_params.rs
@@ -247,7 +247,7 @@ impl UsesTypeParams for syn::TypeParamBound {
 #[cfg(test)]
 mod tests {
     use proc_macro2::Span;
-    use syn::{DeriveInput, Ident};
+    use syn::{parse_quote, DeriveInput, Ident};
 
     use super::UsesTypeParams;
     use crate::usage::IdentSet;

--- a/core/src/util/ident_string.rs
+++ b/core/src/util/ident_string.rs
@@ -137,6 +137,8 @@ impl FromMeta for IdentString {
 
 #[cfg(test)]
 mod tests {
+    use syn::parse_quote;
+
     use super::IdentString;
 
     #[test]

--- a/core/src/util/path_list.rs
+++ b/core/src/util/path_list.rs
@@ -66,6 +66,7 @@ mod tests {
     use super::PathList;
     use crate::FromMeta;
     use proc_macro2::TokenStream;
+    use quote::quote;
     use syn::{parse_quote, Attribute, Meta};
 
     /// parse a string as a syn::Meta instance.

--- a/core/src/util/path_list.rs
+++ b/core/src/util/path_list.rs
@@ -66,7 +66,7 @@ mod tests {
     use super::PathList;
     use crate::FromMeta;
     use proc_macro2::TokenStream;
-    use syn::{Attribute, Meta};
+    use syn::{parse_quote, Attribute, Meta};
 
     /// parse a string as a syn::Meta instance.
     fn pm(tokens: TokenStream) -> ::std::result::Result<Meta, String> {


### PR DESCRIPTION
This should be non-functional code cleanup.

Doing this sets the stage for re-exporting `syn` from `darling::export` via `darling_core`, which would remove the need for users of `darling` to have `syn` in scope under that name.