### PR TITLE
Fix spans when field does not impl FromMeta

### DIFF
--- a/.github/workflows/compiletests.yml
+++ b/.github/workflows/compiletests.yml
@@ -1,0 +1,24 @@
+name: Compile Test
+
+on: [push, pull_request]
+
+jobs:
+    compiletest:
+        runs-on: ubuntu-latest
+
+        env:
+            RUST_BACKTRACE: 1
+            RUSTFLAGS: "--cfg compiletests"
+
+        steps:
+            - uses: actions/checkout@v2
+
+            - uses: actions-rs/toolchain@v1
+              with:
+                  toolchain: 1.65.0
+                  override: true
+
+            - name: main crate
+              run: |
+                  cargo build --verbose
+                  cargo test --no-fail-fast --verbose --test compiletests -- --nocapture

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,10 @@ proc-macro2 = "1.0.37"
 quote = "1.0.18"
 syn = "1.0.91"
 
+[target.'cfg(compiletests)'.dev-dependencies]
+rustversion = "1.0.9"
+trybuild = "1.0.38"
+
 [features]
 default = ["suggestions"]
 diagnostics = ["darling_core/diagnostics"]

--- a/compiletests.sh
+++ b/compiletests.sh
@@ -1,0 +1,1 @@
+RUSTFLAGS="--cfg=compiletests" cargo +1.65.0 test --test compiletests

--- a/core/src/codegen/field.rs
+++ b/core/src/codegen/field.rs
@@ -1,8 +1,8 @@
 use std::borrow::Cow;
 
 use proc_macro2::TokenStream;
-use quote::{quote, ToTokens, TokenStreamExt};
-use syn::{Ident, Path, Type};
+use quote::{quote, quote_spanned, ToTokens, TokenStreamExt};
+use syn::{spanned::Spanned, Ident, Path, Type};
 
 use crate::codegen::{DefaultExpression, PostfixTransform};
 use crate::usage::{self, IdentRefSet, IdentSet, UsesTypeParams};
@@ -102,11 +102,15 @@ impl<'a> ToTokens for MatchArm<'a> {
                 quote!(#name_str)
             };
 
-            // Add the span immediately on extraction failure, so that it's as specific as possible.
+            // Give darling's generated code the span of the `with_path` so that if the target
+            // type doesn't impl FromMeta, darling's immediate user gets a properly-spanned error.
+            //
+            // Within the generated code, add the span immediately on extraction failure, so that it's
+            // as specific as possible.
             // The behavior of `with_span` makes this safe to do; if the child applied an
             // even-more-specific span, our attempt here will not overwrite that and will only cost
             // us one `if` check.
-            let extractor = quote!(#with_path(__inner)#post_transform.map_err(|e| e.with_span(&__inner).at(#location)));
+            let extractor = quote_spanned!(with_path.span()=>#with_path(__inner)#post_transform.map_err(|e| e.with_span(&__inner).at(#location)));
 
             tokens.append_all(if field.multiple {
                 quote!(
@@ -172,9 +176,14 @@ impl<'a> ToTokens for CheckMissing<'a> {
             let ty = self.0.ty;
             let name_in_attr = &self.0.name_in_attr;
 
+            // If `ty` does not impl FromMeta, the compiler error should point
+            // at the offending type rather than at the derive-macro call site.
+            let from_none_call =
+                quote_spanned!(ty.span()=> <#ty as ::darling::FromMeta>::from_none());
+
             tokens.append_all(quote! {
                 if !#ident.0 {
-                    match <#ty as ::darling::FromMeta>::from_none() {
+                    match #from_none_call {
                         ::darling::export::Some(__type_fallback) => {
                             #ident.1 = ::darling::export::Some(__type_fallback);
                         }

--- a/core/src/options/input_field.rs
+++ b/core/src/options/input_field.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use syn::parse_quote;
+use syn::{parse_quote_spanned, spanned::Spanned};
 
 use crate::codegen;
 use crate::options::{Core, DefaultExpression, ParseAttribute};
@@ -33,7 +33,11 @@ impl InputField {
             ty: &self.ty,
             default_expression: self.as_codegen_default(),
             with_path: self.with.as_ref().map_or_else(
-                || Cow::Owned(parse_quote!(::darling::FromMeta::from_meta)),
+                || {
+                    Cow::Owned(
+                        parse_quote_spanned!(self.ty.span()=> ::darling::FromMeta::from_meta),
+                    )
+                },
                 Cow::Borrowed,
             ),
             skip: self.skip.unwrap_or_default(),

--- a/tests/compile-fail/not_impl_from_meta.rs
+++ b/tests/compile-fail/not_impl_from_meta.rs
@@ -1,0 +1,16 @@
+use darling::FromMeta;
+
+struct NotImplFm;
+
+#[derive(FromMeta)]
+struct OuterFm {
+    inner: NotImplFm,
+}
+
+#[derive(darling::FromDeriveInput)]
+#[darling(attributes(hello))]
+struct OuterFdi {
+    inner: NotImplFm,
+}
+
+fn main() {}

--- a/tests/compile-fail/not_impl_from_meta.stderr
+++ b/tests/compile-fail/not_impl_from_meta.stderr
@@ -1,0 +1,33 @@
+error[E0277]: the trait bound `NotImplFm: FromMeta` is not satisfied
+ --> tests/compile-fail/not_impl_from_meta.rs:7:12
+  |
+7 |     inner: NotImplFm,
+  |            ^^^^^^^^^ the trait `FromMeta` is not implemented for `NotImplFm`
+  |
+  = help: the following other types implement trait `FromMeta`:
+            ()
+            Arc<T>
+            AtomicBool
+            ExprArray
+            ExprPath
+            Flag
+            HashMap<String, V, S>
+            HashMap<proc_macro2::Ident, V, S>
+          and $N others
+
+error[E0277]: the trait bound `NotImplFm: FromMeta` is not satisfied
+  --> tests/compile-fail/not_impl_from_meta.rs:13:12
+   |
+13 |     inner: NotImplFm,
+   |            ^^^^^^^^^ the trait `FromMeta` is not implemented for `NotImplFm`
+   |
+   = help: the following other types implement trait `FromMeta`:
+             ()
+             Arc<T>
+             AtomicBool
+             ExprArray
+             ExprPath
+             Flag
+             HashMap<String, V, S>
+             HashMap<proc_macro2::Ident, V, S>
+           and $N others

--- a/tests/compiletests.rs
+++ b/tests/compiletests.rs
@@ -1,0 +1,16 @@
+#![cfg(compiletests)]
+
+#[rustversion::stable(1.65)]
+#[test]
+fn compile_test() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/compile-fail/*.rs");
+}
+
+#[rustversion::not(stable(1.65))]
+#[test]
+fn wrong_rustc_version() {
+    panic!(
+        "This is not the expected version of rustc. Error messages vary across compiler versions so tests may produce spurious errors"
+    );
+}


### PR DESCRIPTION
* Add `trybuild` for compile-test infrastructure
* Fix spans when field does not impl FromMeta