### PR TITLE
Make spans of SpannedValue more precise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Re-export `syn` from `darling` to avoid requiring that consuming crates have a `syn` dependency.
+- Change `<SpannedValue<T> as FromMeta>` impl to more precisely capture the _value_ span, as opposed to the span of the entire item.
 
 ## v0.14.2 (October 26, 2022)
 

--- a/core/src/util/spanned_value.rs
+++ b/core/src/util/spanned_value.rs
@@ -86,10 +86,28 @@ macro_rules! spanned {
     };
 }
 
+impl<T: FromMeta> FromMeta for SpannedValue<T> {
+    fn from_meta(item: &syn::Meta) -> Result<Self> {
+        let value = T::from_meta(item).map_err(|e| e.with_span(item))?;
+        let span = match item {
+            // Example: `#[darling(skip)]` as SpannedValue<bool>
+            // should have the span pointing to the word `skip`.
+            syn::Meta::Path(path) => path.span(),
+            // Example: `#[darling(attributes(Value))]` as a SpannedValue<Vec<String>>
+            // should have the span pointing to the list contents.
+            syn::Meta::List(list) => list.nested.span(),
+            // Example: `#[darling(skip = true)]` as SpannedValue<bool>
+            // should have the span pointing to the word `true`.
+            syn::Meta::NameValue(nv) => nv.lit.span(),
+        };
+
+        Ok(Self::new(value, span))
+    }
+}
+
 spanned!(FromGenericParam, from_generic_param, syn::GenericParam);
 spanned!(FromGenerics, from_generics, syn::Generics);
 spanned!(FromTypeParam, from_type_param, syn::TypeParam);
-spanned!(FromMeta, from_meta, syn::Meta);
 spanned!(FromDeriveInput, from_derive_input, syn::DeriveInput);
 spanned!(FromField, from_field, syn::Field);
 spanned!(FromVariant, from_variant, syn::Variant);


### PR DESCRIPTION
Only capture path when using path meta items; otherwise just span the actual value.