### PR TITLE
Keep span information for use of Default::default

### DIFF
--- a/core/src/codegen/field.rs
+++ b/core/src/codegen/field.rs
@@ -9,7 +9,7 @@ use crate::usage::{self, IdentRefSet, IdentSet, UsesTypeParams};
 
 /// Properties needed to generate code for a field in all the contexts
 /// where one may appear.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct Field<'a> {
     /// The name presented to the user of the library. This will appear
     /// in error messages and will be looked when parsing names.

--- a/core/src/codegen/variant.rs
+++ b/core/src/codegen/variant.rs
@@ -10,7 +10,7 @@ use crate::codegen::{Field, FieldsGen};
 use crate::usage::{self, IdentRefSet, IdentSet, UsesTypeParams};
 
 /// A variant of the enum which is deriving `FromMeta`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct Variant<'a> {
     /// The name which will appear in code passed to the `FromMeta` input.
     pub name_in_attr: Cow<'a, String>,

--- a/core/src/options/core.rs
+++ b/core/src/options/core.rs
@@ -66,9 +66,13 @@ impl Core {
     fn as_codegen_default(&self) -> Option<codegen::DefaultExpression<'_>> {
         self.default.as_ref().map(|expr| match *expr {
             DefaultExpression::Explicit(ref path) => codegen::DefaultExpression::Explicit(path),
-            DefaultExpression::Inherit | DefaultExpression::Trait => {
-                codegen::DefaultExpression::Trait
+            DefaultExpression::Inherit => {
+                // It should be impossible for any input to get here,
+                // so panic rather than returning an error or pretending
+                // everything is fine.
+                panic!("DefaultExpression::Inherit is not valid at container level")
             }
+            DefaultExpression::Trait { span } => codegen::DefaultExpression::Trait { span },
         })
     }
 }

--- a/core/src/options/input_field.rs
+++ b/core/src/options/input_field.rs
@@ -4,9 +4,10 @@ use syn::{parse_quote_spanned, spanned::Spanned};
 
 use crate::codegen;
 use crate::options::{Core, DefaultExpression, ParseAttribute};
+use crate::util::SpannedValue;
 use crate::{Error, FromMeta, Result};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct InputField {
     pub ident: syn::Ident,
     pub attr_name: Option<String>,
@@ -16,7 +17,7 @@ pub struct InputField {
 
     /// If `true`, generated code will not look for this field in the input meta item,
     /// instead always falling back to either `InputField::default` or `Default::default`.
-    pub skip: Option<bool>,
+    pub skip: Option<SpannedValue<bool>>,
     pub post_transform: Option<codegen::PostfixTransform>,
     pub multiple: Option<bool>,
 }
@@ -40,7 +41,7 @@ impl InputField {
                 },
                 Cow::Borrowed,
             ),
-            skip: self.skip.unwrap_or_default(),
+            skip: *self.skip.unwrap_or_default(),
             post_transform: self.post_transform.as_ref(),
             multiple: self.multiple.unwrap_or_default(),
         }
@@ -52,7 +53,7 @@ impl InputField {
         self.default.as_ref().map(|expr| match *expr {
             DefaultExpression::Explicit(ref path) => codegen::DefaultExpression::Explicit(path),
             DefaultExpression::Inherit => codegen::DefaultExpression::Inherit(&self.ident),
-            DefaultExpression::Trait => codegen::DefaultExpression::Trait,
+            DefaultExpression::Trait { span } => codegen::DefaultExpression::Trait { span },
         })
     }
 
@@ -97,11 +98,7 @@ impl InputField {
         // 1. Will we look for this field in the attribute?
         // 1. Is there a locally-defined default?
         // 1. Did the parent define a default?
-        self.default = match (
-            self.skip.unwrap_or_default(),
-            self.default.is_some(),
-            parent.default.is_some(),
-        ) {
+        self.default = match (&self.skip, self.default.is_some(), parent.default.is_some()) {
             // If we have a default, use it.
             (_, true, _) => self.default,
 
@@ -110,11 +107,13 @@ impl InputField {
             (_, false, true) => Some(DefaultExpression::Inherit),
 
             // If we're skipping the field and no defaults have been expressed then we should
-            // use the ::darling::export::Default trait.
-            (true, false, false) => Some(DefaultExpression::Trait),
+            // use the ::darling::export::Default trait, and set the span to the skip keyword
+            // so that an error caused by the skipped field's type not implementing `Default`
+            // will correctly identify why darling is trying to use `Default`.
+            (Some(v), false, false) if **v => Some(DefaultExpression::Trait { span: v.span() }),
 
             // If we don't have or need a default, then leave it blank.
-            (false, false, false) => None,
+            (_, false, false) => None,
         };
 
         self

--- a/core/src/options/input_variant.rs
+++ b/core/src/options/input_variant.rs
@@ -5,7 +5,7 @@ use crate::codegen;
 use crate::options::{Core, InputField, ParseAttribute};
 use crate::{Error, FromMeta, Result};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct InputVariant {
     ident: syn::Ident,
     attr_name: Option<String>,

--- a/core/src/options/outer_from.rs
+++ b/core/src/options/outer_from.rs
@@ -1,3 +1,4 @@
+use syn::spanned::Spanned;
 use syn::{Field, Ident, Meta};
 
 use crate::options::{Core, DefaultExpression, ForwardAttrs, ParseAttribute, ParseData};
@@ -50,7 +51,11 @@ impl ParseAttribute for OuterFrom {
         } else if path.is_ident("from_ident") {
             // HACK: Declaring that a default is present will cause fields to
             // generate correct code, but control flow isn't that obvious.
-            self.container.default = Some(DefaultExpression::Trait);
+            self.container.default = Some(DefaultExpression::Trait {
+                // Use the span of the `from_ident` keyword so that errors in generated code
+                // caused by this will point back to the correct location.
+                span: path.span(),
+            });
             self.from_ident = true;
         } else {
             return self.container.parse_nested(mi);

--- a/tests/compile-fail/skip_field_not_impl_default.rs
+++ b/tests/compile-fail/skip_field_not_impl_default.rs
@@ -1,0 +1,18 @@
+use darling::FromMeta;
+
+#[derive(FromMeta)]
+struct NoDefault(String);
+
+#[derive(FromMeta)]
+struct Recevier {
+    #[darling(skip)]
+    skipped: NoDefault,
+
+    #[darling(skip = true)]
+    explicitly_skipped: NoDefault,
+
+    #[darling(skip = false)]
+    not_skipped_no_problem: NoDefault,
+}
+
+fn main() {}

--- a/tests/compile-fail/skip_field_not_impl_default.stderr
+++ b/tests/compile-fail/skip_field_not_impl_default.stderr
@@ -1,0 +1,21 @@
+error[E0277]: the trait bound `NoDefault: std::default::Default` is not satisfied
+ --> tests/compile-fail/skip_field_not_impl_default.rs:8:15
+  |
+8 |     #[darling(skip)]
+  |               ^^^^ the trait `std::default::Default` is not implemented for `NoDefault`
+  |
+help: consider annotating `NoDefault` with `#[derive(Default)]`
+  |
+4 | #[derive(Default)]
+  |
+
+error[E0277]: the trait bound `NoDefault: std::default::Default` is not satisfied
+  --> tests/compile-fail/skip_field_not_impl_default.rs:11:22
+   |
+11 |     #[darling(skip = true)]
+   |                      ^^^^ the trait `std::default::Default` is not implemented for `NoDefault`
+   |
+help: consider annotating `NoDefault` with `#[derive(Default)]`
+   |
+4  | #[derive(Default)]
+   |


### PR DESCRIPTION
This improves error messages when generated code tries to get a default value and one isn't supported.