### PR TITLE
Define FromData trait

### DIFF
--- a/core/src/ast/data.rs
+++ b/core/src/ast/data.rs
@@ -4,6 +4,7 @@ use proc_macro2::{Span, TokenStream};
 use quote::{quote, quote_spanned, ToTokens};
 use syn::spanned::Spanned;
 
+use crate::from_data::FromData;
 use crate::usage::{
     self, IdentRefSet, IdentSet, LifetimeRefSet, LifetimeSet, UsesLifetimes, UsesTypeParams,
 };
@@ -136,6 +137,12 @@ impl<V: FromVariant, F: FromField> Data<V, F> {
             // putting it on the union keyword ends up being confusing.
             syn::Data::Union(_) => Err(Error::custom("Unions are not supported")),
         }
+    }
+}
+
+impl<V: FromVariant, F: FromField> FromData for Data<V, F> {
+    fn from_data(data: &syn::Data) -> Result<Self> {
+        Self::try_from(data)
     }
 }
 

--- a/core/src/codegen/from_derive_impl.rs
+++ b/core/src/codegen/from_derive_impl.rs
@@ -58,7 +58,7 @@ impl<'a> ToTokens for FromDeriveInputImpl<'a> {
         let passed_body = self
             .data
             .as_ref()
-            .map(|i| quote!(#i: ::darling::ast::Data::try_from(&#input.data)?,));
+            .map(|i| quote!(#i: ::darling::FromData::from_data(&#input.data)?,));
 
         let supports = self.supports.map(|i| {
             quote! {

--- a/core/src/from_data.rs
+++ b/core/src/from_data.rs
@@ -1,0 +1,20 @@
+use syn::Data;
+
+use crate::Result;
+
+/// Creates an instance by parsing an syn::Data.
+pub trait FromData: Sized {
+    fn from_data(data: &Data) -> Result<Self>;
+}
+
+impl FromData for () {
+    fn from_data(_: &Data) -> Result<Self> {
+        Ok(())
+    }
+}
+
+impl FromData for Data {
+    fn from_data(data: &Data) -> Result<Self> {
+        Ok(data.clone())
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -14,6 +14,7 @@ pub(crate) mod codegen;
 pub mod derive;
 pub mod error;
 mod from_attributes;
+mod from_data;
 mod from_derive_input;
 mod from_field;
 mod from_generic_param;
@@ -27,6 +28,7 @@ pub mod util;
 
 pub use self::error::{Error, Result};
 pub use self::from_attributes::FromAttributes;
+pub use self::from_data::FromData;
 pub use self::from_derive_input::FromDeriveInput;
 pub use self::from_field::FromField;
 pub use self::from_generic_param::FromGenericParam;

--- a/core/src/util/ignored.rs
+++ b/core/src/util/ignored.rs
@@ -1,6 +1,6 @@
 use crate::{
     usage::{self, UsesLifetimes, UsesTypeParams},
-    FromDeriveInput, FromField, FromGenericParam, FromGenerics, FromMeta, FromTypeParam,
+    FromData, FromDeriveInput, FromField, FromGenericParam, FromGenerics, FromMeta, FromTypeParam,
     FromVariant, Result,
 };
 
@@ -28,6 +28,7 @@ ignored!(FromMeta, from_meta, syn::Meta);
 ignored!(FromDeriveInput, from_derive_input, syn::DeriveInput);
 ignored!(FromField, from_field, syn::Field);
 ignored!(FromVariant, from_variant, syn::Variant);
+ignored!(FromData, from_data, syn::Data);
 
 impl UsesTypeParams for Ignored {
     fn uses_type_params<'a>(

--- a/core/src/util/with_original.rs
+++ b/core/src/util/with_original.rs
@@ -1,5 +1,5 @@
 use crate::{
-    FromDeriveInput, FromField, FromGenericParam, FromGenerics, FromMeta, FromTypeParam,
+    FromData, FromDeriveInput, FromField, FromGenericParam, FromGenerics, FromMeta, FromTypeParam,
     FromVariant, Result,
 };
 
@@ -33,3 +33,4 @@ with_original!(FromGenericParam, from_generic_param, syn::GenericParam);
 with_original!(FromMeta, from_meta, syn::Meta);
 with_original!(FromTypeParam, from_type_param, syn::TypeParam);
 with_original!(FromVariant, from_variant, syn::Variant);
+with_original!(FromData, from_data, syn::Data);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ pub use darling_macro::*;
 
 #[doc(inline)]
 pub use darling_core::{
-    FromAttributes, FromDeriveInput, FromField, FromGenericParam, FromGenerics, FromMeta,
+    FromAttributes, FromData, FromDeriveInput, FromField, FromGenericParam, FromGenerics, FromMeta,
     FromTypeParam, FromVariant,
 };
 

--- a/tests/custom_data.rs
+++ b/tests/custom_data.rs
@@ -1,0 +1,89 @@
+use darling::{ast, FromDeriveInput, FromVariant};
+use darling_core::FromData;
+
+#[derive(Debug, FromDeriveInput)]
+#[darling(attributes(from_variants))]
+pub struct Container {
+    pub data: MyData,
+}
+
+#[derive(Default, Debug, FromVariant)]
+#[darling(default, attributes(from_variants))]
+pub struct Variant {
+    into: Option<bool>,
+    skip: Option<bool>,
+}
+
+#[derive(Debug)]
+pub struct MyData {
+    pub variants: Vec<Variant>,
+}
+
+impl FromData for MyData {
+    fn from_data(data: &syn::Data) -> darling_core::Result<Self> {
+        let data: ast::Data<Variant, ()> = FromData::from_data(data)?;
+        match data {
+            ast::Data::Enum(variants) => Ok(MyData { variants }),
+            ast::Data::Struct(_) => Err(darling_core::Error::unsupported_shape("struct")),
+        }
+    }
+}
+
+mod source {
+    use syn::{parse_quote, DeriveInput};
+
+    pub fn newtype_enum() -> DeriveInput {
+        parse_quote! {
+            enum Hello {
+                World(bool),
+                String(String),
+            }
+        }
+    }
+
+    pub fn named_field_enum() -> DeriveInput {
+        parse_quote! {
+            enum Hello {
+                Foo(u16),
+                World {
+                    name: String
+                },
+            }
+        }
+    }
+
+    pub fn empty_enum() -> DeriveInput {
+        parse_quote! {
+            enum Hello {}
+        }
+    }
+
+    pub fn named_struct() -> DeriveInput {
+        parse_quote! {
+            struct Hello {
+                world: bool,
+            }
+        }
+    }
+
+    pub fn tuple_struct() -> DeriveInput {
+        parse_quote! { struct Hello(String, bool); }
+    }
+}
+
+#[test]
+fn enum_not_struct() {
+    // Should pass
+    let container = Container::from_derive_input(&source::newtype_enum()).unwrap();
+    assert_eq!(container.data.variants.len(), 2);
+
+    let container = Container::from_derive_input(&source::named_field_enum()).unwrap();
+    assert_eq!(container.data.variants.len(), 2);
+
+    let container = Container::from_derive_input(&source::empty_enum()).unwrap();
+    assert_eq!(container.data.variants.len(), 0);
+
+    // Should error
+    Container::from_derive_input(&source::named_struct()).unwrap_err();
+    Container::from_derive_input(&source::tuple_struct()).unwrap_err();
+}


### PR DESCRIPTION
define `FromData` trait, so the user can defines custom type for the data field in `FromDeriveInput`

example:

```rust

#[derive(Debug, FromDeriveInput)]
#[darling(attributes(from_variants))]
pub struct Container {
    pub data: MyData,
}

#[derive(Default, Debug, FromVariant)]
#[darling(default, attributes(from_variants))]
pub struct Variant {
    into: Option<bool>,
    skip: Option<bool>,
}

#[derive(Debug)]
pub struct MyData {
    pub variants: Vec<Variant>,
}

impl FromData for MyData {
    fn from_data(data: &syn::Data) -> darling::Result<Self> {
        let data: ast::Data<Variant, ()> = FromData::from_data(data)?;
        match data {
            ast::Data::Enum(variants) => Ok(MyData { variants }),
            ast::Data::Struct(_) => Err(darling_core::Error::unsupported_shape("struct")),
        }
    }
}
```