### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           - { rust: 1.31.0, os: ubuntu-latest }
           - { rust: 1.31.0, os: windows-latest }
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@nightly
       - uses: Swatinem/rust-cache@v1
       - name: Check Cargo availability
@@ -55,7 +55,7 @@ jobs:
     env:
       RUSTFLAGS: -Dwarnings
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -67,7 +67,7 @@ jobs:
     name: Verify code formatting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,9 @@ jobs:
           - { rust: 1.31.0, os: windows-latest }
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
       - uses: Swatinem/rust-cache@v1
       - name: Check Cargo availability
         run: cargo --version
@@ -44,10 +43,7 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          override: true
+      - uses: dtolnay/rust-toolchain@nightly
       - uses: Swatinem/rust-cache@v1
       - name: Check Cargo availability
         run: cargo --version
@@ -60,11 +56,8 @@ jobs:
       RUSTFLAGS: -Dwarnings
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
           components: clippy
       - uses: Swatinem/rust-cache@v1
       - name: Run clippy --workspace --tests
@@ -75,15 +68,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
           components: rustfmt
       - uses: Swatinem/rust-cache@v1
       - name: Run fmt --all -- --check
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - name: Check Cargo availability
         run: cargo --version
       - run: cargo test --verbose --all
@@ -44,7 +44,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@nightly
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - name: Check Cargo availability
         run: cargo --version
       - run: cargo test --verbose --workspace --features diagnostics
@@ -59,7 +59,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - name: Run clippy --workspace --tests
         run: cargo clippy --workspace --tests
 
@@ -71,6 +71,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - name: Run fmt --all -- --check
         run: cargo fmt --all -- --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ jobs:
           - { rust: stable, os: macos-latest }
           - { rust: stable, os: windows-latest }
           - { rust: 1.31.0, os: ubuntu-latest }
-          - { rust: 1.31.0, os: macos-latest }
           - { rust: 1.31.0, os: windows-latest }
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/compiletests.yml
+++ b/.github/workflows/compiletests.yml
@@ -11,13 +11,8 @@ jobs:
             RUSTFLAGS: "--cfg compiletests"
 
         steps:
-            - uses: actions/checkout@v2
-
-            - uses: actions-rs/toolchain@v1
-              with:
-                  toolchain: 1.65.0
-                  override: true
-
+            - uses: actions/checkout@v3
+            - uses: dtolnay/rust-toolchain@1.65.0
             - name: main crate
               run: |
                   cargo build --verbose


### PR DESCRIPTION
- Stop running tests on 1.31 on macOS since they keep failing
- Use `dtolnay/rust-toolchain` instead of unmaintained `actions-rs`
- Update `actions/checkout` to v3
- Update `swatinem/rust-cache` to v2