### PR TITLE
Allow `Clone`ing `NestedMeta`

### DIFF
--- a/core/src/ast/data.rs
+++ b/core/src/ast/data.rs
@@ -413,7 +413,7 @@ impl<'a> From<&'a syn::Fields> for Style {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum NestedMeta {
     Meta(syn::Meta),
     Lit(syn::Lit),


### PR DESCRIPTION
Resolves the only thing that broke in my codebase when updating to `0.20`.