### PR TITLE
Accept paths and idents without quotation marks in value positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Allow darling users to omit quotation marks for paths and idents
+
 ## v0.20.1 (May 2, 2023)
 
 - Add `Clone` impl for `NestedMeta` [#230](https://github.com/TedDriggs/darling/pull/230)

--- a/examples/fallible_read.rs
+++ b/examples/fallible_read.rs
@@ -10,10 +10,10 @@ use darling::{FromDeriveInput, FromMeta};
 use syn::parse_str;
 
 #[derive(Debug, FromDeriveInput)]
-#[darling(attributes(my_trait), and_then = "MyInputReceiver::autocorrect")]
+#[darling(attributes(my_trait), and_then = MyInputReceiver::autocorrect)]
 pub struct MyInputReceiver {
     /// This field must be present and a string or else parsing will panic.
-    #[darling(map = "MyInputReceiver::make_string_shouty")]
+    #[darling(map = MyInputReceiver::make_string_shouty)]
     name: String,
 
     /// If this field fails to parse, the struct can still be built; the field

--- a/tests/unsupported_attributes.rs
+++ b/tests/unsupported_attributes.rs
@@ -11,39 +11,21 @@ pub struct Bar {
 
 /// Per [#96](https://github.com/TedDriggs/darling/issues/96), make sure that an
 /// attribute which isn't a valid meta gets an error.
-#[test]
-fn non_meta_attribute_gets_own_error() {
-    let di = parse_quote! {
-        #[derive(Bar)]
-        #[bar(file = "motors/example_6.csv", st = RocketEngine)]
-        pub struct EstesC6;
-    };
-
-    let errors: darling::Error = Bar::from_derive_input(&di).unwrap_err().flatten();
-    // The number of errors here is 1 for the bad value of the `st` attribute
-    assert_eq!(1, errors.len());
-    // Make sure one of the errors propagates the syn error
-    assert!(errors
-        .into_iter()
-        .any(|e| e.to_string().contains("expected lit")));
-}
-
 /// Properties can be split across multiple attributes; this test ensures that one
 /// non-meta attribute does not interfere with the parsing of other, well-formed attributes.
 #[test]
 fn non_meta_attribute_does_not_block_others() {
     let di = parse_quote! {
         #[derive(Bar)]
-        #[bar(st = RocketEngine)]
+        #[bar(st = RocketEngine: Debug)]
         #[bar(file = "motors/example_6.csv")]
         pub struct EstesC6;
     };
 
     let errors: darling::Error = Bar::from_derive_input(&di).unwrap_err().flatten();
-    // The number of errors here is 1 for the bad value of the `st` attribute
-    assert_eq!(1, errors.len());
-    // Make sure one of the errors propagates the syn error
-    assert!(errors
-        .into_iter()
-        .any(|e| e.to_string().contains("expected lit")));
+    // The number of errors here is 2:
+    // - The parsing error caused by a where-clause body where it doesn't belong
+    // - The missing `st` value because the parsing failure blocked that attribute from
+    //   being read.
+    assert_eq!(2, errors.len());
 }


### PR DESCRIPTION
This makes these more idiomatic with syn 2, as discussed in #229 