### PR TITLE
Fix misleading error message on UnexpectedType

### DIFF
--- a/core/src/error/kind.rs
+++ b/core/src/error/kind.rs
@@ -44,7 +44,7 @@ impl ErrorKind {
             UnknownField(_) => "Unexpected field",
             UnsupportedShape { .. } => "Unsupported shape",
             UnexpectedFormat(_) => "Unexpected meta-item format",
-            UnexpectedType(_) => "Unexpected literal type",
+            UnexpectedType(_) => "Unexpected type",
             UnknownValue(_) => "Unknown literal value",
             TooFewItems(_) => "Too few items",
             TooManyItems(_) => "Too many items",
@@ -84,7 +84,7 @@ impl fmt::Display for ErrorKind {
                 Ok(())
             }
             UnexpectedFormat(ref format) => write!(f, "Unexpected meta-item format `{}`", format),
-            UnexpectedType(ref ty) => write!(f, "Unexpected literal type `{}`", ty),
+            UnexpectedType(ref ty) => write!(f, "Unexpected type `{}`", ty),
             UnknownValue(ref val) => write!(f, "Unknown literal value `{}`", val),
             TooFewItems(ref min) => write!(f, "Too few items: Expected at least {}", min),
             TooManyItems(ref max) => write!(f, "Too many items: Expected no more than {}", max),


### PR DESCRIPTION
It's currently named "Unexpected litteral type", but it can also be instantiated when not parsing a litteral, e.g. https://github.com/TedDriggs/darling/blob/224a866727cd9e40c2cd80430852b1ea0deeb40e/core/src/error/mod.rs#L152
This specifically made investigation of https://github.com/TedDriggs/darling/pull/263 more difficult.