### PR TITLE
Add FromMeta for Vec<LitStr> & co

### DIFF
--- a/core/src/from_meta.rs
+++ b/core/src/from_meta.rs
@@ -1070,4 +1070,15 @@ mod tests {
             vec![0x50, 0xffffffff]
         );
     }
+
+    #[test]
+    fn test_lit_array() {
+        fm::<Vec<syn::LitStr>>(quote!(ignore = "[\"Hello World\", \"Test Array\"]"));
+        fm::<Vec<syn::LitStr>>(quote!(ignore = ["Hello World", "Test Array"]));
+        fm::<Vec<syn::LitChar>>(quote!(ignore = "['a', 'b', 'c']"));
+        fm::<Vec<syn::LitBool>>(quote!(ignore = "[true]"));
+        fm::<Vec<syn::LitStr>>(quote!(ignore = "[]"));
+        fm::<Vec<syn::LitStr>>(quote!(ignore = []));
+        fm::<Vec<syn::LitBool>>(quote!(ignore = [true, false]));
+    }
 }

--- a/core/src/from_meta.rs
+++ b/core/src/from_meta.rs
@@ -519,7 +519,10 @@ macro_rules! from_meta_lit {
 
         impl FromMeta for Vec<$impl_ty> {
             fn from_list(items: &[NestedMeta]) -> Result<Self> {
-                items.iter().map(<$impl_ty as FromMeta>::from_nested_meta).collect()
+                items
+                    .iter()
+                    .map(<$impl_ty as FromMeta>::from_nested_meta)
+                    .collect()
             }
 
             fn from_value(value: &syn::Lit) -> Result<Self> {
@@ -529,13 +532,11 @@ macro_rules! from_meta_lit {
 
             fn from_expr(expr: &syn::Expr) -> Result<Self> {
                 match expr {
-                    syn::Expr::Array(expr_array) => {
-                        expr_array
-                            .elems
-                            .iter()
-                            .map(<$impl_ty as FromMeta>::from_expr)
-                            .collect::<Result<Vec<_>>>()
-                    }
+                    syn::Expr::Array(expr_array) => expr_array
+                        .elems
+                        .iter()
+                        .map(<$impl_ty as FromMeta>::from_expr)
+                        .collect::<Result<Vec<_>>>(),
                     syn::Expr::Lit(expr_lit) => Self::from_value(&expr_lit.lit),
                     syn::Expr::Group(g) => Self::from_expr(&g.expr),
                     _ => Err(Error::unexpected_expr_type(expr)),


### PR DESCRIPTION
This allows parsing meta attributes of the form `#[foo(bar = ["a", "b", "c"])]` to `Vec<syn::LitStr>` (and same for other `Lit`s).