### PR TITLE
CI: Bump GitHub actions/checkout to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
                     - { rust: 1.56.0, os: ubuntu-latest }
                     - { rust: 1.56.0, os: windows-latest }
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
             - uses: dtolnay/rust-toolchain@master
               with:
                   toolchain: ${{ matrix.rust }}
@@ -42,7 +42,7 @@ jobs:
         runs-on: ubuntu-latest
         continue-on-error: true
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
             - uses: dtolnay/rust-toolchain@nightly
             - uses: Swatinem/rust-cache@v2
             - name: Check Cargo availability
@@ -55,7 +55,7 @@ jobs:
         env:
             RUSTFLAGS: -Dwarnings
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
             - uses: dtolnay/rust-toolchain@stable
               with:
                   components: clippy
@@ -67,7 +67,7 @@ jobs:
         name: Verify code formatting
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
             - uses: dtolnay/rust-toolchain@stable
               with:
                   components: rustfmt

--- a/.github/workflows/compiletests.yml
+++ b/.github/workflows/compiletests.yml
@@ -11,7 +11,7 @@ jobs:
             RUSTFLAGS: "--cfg compiletests"
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
             - uses: dtolnay/rust-toolchain@1.65.0
             - name: main crate
               run: |


### PR DESCRIPTION
This removes a number of warnings from CI execution.