### PR TITLE
Flatten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+-  Add `#[darling(flatten)]` to allow forwarding unknown fields to another struct [#146](https://github.com/TedDriggs/darling/issues/146)
 -  Don't suggest names of skipped fields in derived impls [#268](https://github.com/TedDriggs/darling/issues/268)
 
 ## v0.20.6 (February 14, 2024)

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Darling's features are built to work well for real-world projects.
 -   **Multiple-occurrence fields**: Use `#[darling(multiple)]` on a `Vec` field to allow that field to appear multiple times in the meta-item. Each occurrence will be pushed into the `Vec`.
 -   **Span access**: Use `darling::util::SpannedValue` in a struct to get access to that meta item's source code span. This can be used to emit warnings that point at a specific field from your proc macro. In addition, you can use `darling::Error::write_errors` to automatically get precise error location details in most cases.
 -   **"Did you mean" suggestions**: Compile errors from derived darling trait impls include suggestions for misspelled fields.
+-   **Struct flattening**: Use `#[darling(flatten)]` to remove one level of structure when presenting your meta item to users. Fields that are not known to the parent struct will be forwarded to the `flatten` field.
 
 ## Shape Validation
 

--- a/core/src/codegen/outer_from_impl.rs
+++ b/core/src/codegen/outer_from_impl.rs
@@ -27,6 +27,7 @@ pub trait OuterFromImpl<'a> {
         let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
         tokens.append_all(quote!(
+            #[automatically_derived]
             impl #impl_generics #trayt for #ty_ident #ty_generics
                 #where_clause
             {

--- a/core/src/codegen/variant_data.rs
+++ b/core/src/codegen/variant_data.rs
@@ -42,7 +42,7 @@ impl<'a> FieldsGen<'a> {
         {
             (
                 quote! { let mut __flatten = vec![]; },
-                Some(flatten_field.as_flatten_initializer()),
+                Some(flatten_field.as_flatten_initializer(self.field_names().collect())),
             )
         } else {
             (quote!(), None)
@@ -118,5 +118,9 @@ impl<'a> FieldsGen<'a> {
         let inits = inits.iter();
 
         quote!(#(#inits),*)
+    }
+
+    fn field_names(&self) -> impl Iterator<Item = &str> {
+        self.fields.iter().filter_map(Field::as_name)
     }
 }

--- a/core/src/error/kind.rs
+++ b/core/src/error/kind.rs
@@ -142,6 +142,24 @@ impl ErrorUnknownField {
         ErrorUnknownField::new(field, did_you_mean(field, alternates))
     }
 
+    /// Add more alternate field names to the error, updating the `did_you_mean` suggestion
+    /// if a closer match to the unknown field's name is found.
+    pub fn add_alts<'a, T, I>(&mut self, alternates: I)
+    where
+        T: AsRef<str> + 'a,
+        I: IntoIterator<Item = &'a T>,
+    {
+        if let Some(bna) = did_you_mean(&self.name, alternates) {
+            if let Some(current) = &self.did_you_mean {
+                if bna.0 > current.0 {
+                    self.did_you_mean = Some(bna);
+                }
+            } else {
+                self.did_you_mean = Some(bna);
+            }
+        }
+    }
+
     #[cfg(feature = "diagnostics")]
     pub fn into_diagnostic(self, span: Option<::proc_macro2::Span>) -> ::proc_macro::Diagnostic {
         let base = span

--- a/core/src/options/from_attributes.rs
+++ b/core/src/options/from_attributes.rs
@@ -51,6 +51,10 @@ impl ParseData for FromAttributesOptions {
     fn parse_field(&mut self, field: &syn::Field) -> Result<()> {
         self.base.parse_field(field)
     }
+
+    fn validate_body(&self, errors: &mut crate::error::Accumulator) {
+        self.base.validate_body(errors);
+    }
 }
 
 impl<'a> From<&'a FromAttributesOptions> for FromAttributesImpl<'a> {

--- a/core/src/options/from_derive.rs
+++ b/core/src/options/from_derive.rs
@@ -68,6 +68,10 @@ impl ParseData for FdiOptions {
             _ => self.base.parse_field(field),
         }
     }
+
+    fn validate_body(&self, errors: &mut crate::error::Accumulator) {
+        self.base.validate_body(errors);
+    }
 }
 
 impl<'a> From<&'a FdiOptions> for FromDeriveInputImpl<'a> {

--- a/core/src/options/from_field.rs
+++ b/core/src/options/from_field.rs
@@ -49,6 +49,10 @@ impl ParseData for FromFieldOptions {
             _ => self.base.parse_field(field),
         }
     }
+
+    fn validate_body(&self, errors: &mut crate::error::Accumulator) {
+        self.base.validate_body(errors);
+    }
 }
 
 impl<'a> From<&'a FromFieldOptions> for FromFieldImpl<'a> {

--- a/core/src/options/from_meta.rs
+++ b/core/src/options/from_meta.rs
@@ -37,6 +37,8 @@ impl ParseData for FromMetaOptions {
     }
 
     fn validate_body(&self, errors: &mut Accumulator) {
+        self.base.validate_body(errors);
+
         if let Data::Enum(ref data) = self.base.data {
             // Adds errors for duplicate `#[darling(word)]` annotations across all variants.
             let word_variants: Vec<_> = data

--- a/core/src/options/from_type_param.rs
+++ b/core/src/options/from_type_param.rs
@@ -49,6 +49,10 @@ impl ParseData for FromTypeParamOptions {
             _ => self.base.parse_field(field),
         }
     }
+
+    fn validate_body(&self, errors: &mut crate::error::Accumulator) {
+        self.base.validate_body(errors);
+    }
 }
 
 impl<'a> From<&'a FromTypeParamOptions> for FromTypeParamImpl<'a> {

--- a/core/src/options/from_variant.rs
+++ b/core/src/options/from_variant.rs
@@ -70,6 +70,10 @@ impl ParseData for FromVariantOptions {
             _ => self.base.parse_field(field),
         }
     }
+
+    fn validate_body(&self, errors: &mut crate::error::Accumulator) {
+        self.base.validate_body(errors);
+    }
 }
 
 impl ToTokens for FromVariantOptions {

--- a/core/src/options/input_field.rs
+++ b/core/src/options/input_field.rs
@@ -45,6 +45,7 @@ impl InputField {
             skip: *self.skip.unwrap_or_default(),
             post_transform: self.post_transform.as_ref(),
             multiple: self.multiple.unwrap_or_default(),
+            flatten: self.flatten.is_present(),
         }
     }
 
@@ -132,6 +133,12 @@ impl ParseAttribute for InputField {
             }
 
             self.attr_name = FromMeta::from_meta(mi)?;
+
+            if self.flatten.is_present() {
+                return Err(
+                    Error::custom("`flatten` and `rename` cannot be used together").with_span(mi),
+                );
+            }
         } else if path.is_ident("default") {
             if self.default.is_some() {
                 return Err(Error::duplicate_field_path(path).with_span(mi));
@@ -143,12 +150,24 @@ impl ParseAttribute for InputField {
             }
 
             self.with = Some(FromMeta::from_meta(mi)?);
+
+            if self.flatten.is_present() {
+                return Err(
+                    Error::custom("`flatten` and `with` cannot be used together").with_span(mi),
+                );
+            }
         } else if path.is_ident("skip") {
             if self.skip.is_some() {
                 return Err(Error::duplicate_field_path(path).with_span(mi));
             }
 
             self.skip = FromMeta::from_meta(mi)?;
+
+            if self.skip.map(|v| *v).unwrap_or_default() && self.flatten.is_present() {
+                return Err(
+                    Error::custom("`flatten` and `skip` cannot be used together").with_span(mi),
+                );
+            }
         } else if path.is_ident("map") || path.is_ident("and_then") {
             let transformer = path.get_ident().unwrap().clone();
             if let Some(post_transform) = &self.post_transform {
@@ -173,12 +192,46 @@ impl ParseAttribute for InputField {
             }
 
             self.multiple = FromMeta::from_meta(mi)?;
+
+            if self.multiple == Some(true) && self.flatten.is_present() {
+                return Err(
+                    Error::custom("`flatten` and `multiple` cannot be used together").with_span(mi),
+                );
+            }
         } else if path.is_ident("flatten") {
             if self.flatten.is_present() {
                 return Err(Error::duplicate_field_path(path).with_span(mi));
             }
 
             self.flatten = FromMeta::from_meta(mi)?;
+
+            let mut conflicts = Error::accumulator();
+
+            if self.multiple == Some(true) {
+                conflicts.push(
+                    Error::custom("`flatten` and `multiple` cannot be used together").with_span(mi),
+                );
+            }
+
+            if self.attr_name.is_some() {
+                conflicts.push(
+                    Error::custom("`flatten` and `rename` cannot be used together").with_span(mi),
+                );
+            }
+
+            if self.with.is_some() {
+                conflicts.push(
+                    Error::custom("`flatten` and `with` cannot be used together").with_span(mi),
+                );
+            }
+
+            if self.skip.map(|v| *v).unwrap_or_default() {
+                conflicts.push(
+                    Error::custom("`flatten` and `skip` cannot be used together").with_span(mi),
+                );
+            }
+
+            conflicts.finish()?;
         } else {
             return Err(Error::unknown_field_path(path).with_span(mi));
         }

--- a/core/src/options/input_field.rs
+++ b/core/src/options/input_field.rs
@@ -4,7 +4,7 @@ use syn::{parse_quote_spanned, spanned::Spanned};
 
 use crate::codegen;
 use crate::options::{Core, DefaultExpression, ParseAttribute};
-use crate::util::SpannedValue;
+use crate::util::{Flag, SpannedValue};
 use crate::{Error, FromMeta, Result};
 
 #[derive(Debug, Clone)]
@@ -20,6 +20,7 @@ pub struct InputField {
     pub skip: Option<SpannedValue<bool>>,
     pub post_transform: Option<codegen::PostfixTransform>,
     pub multiple: Option<bool>,
+    pub flatten: Flag,
 }
 
 impl InputField {
@@ -67,6 +68,7 @@ impl InputField {
             skip: None,
             post_transform: Default::default(),
             multiple: None,
+            flatten: Default::default(),
         }
     }
 
@@ -171,6 +173,12 @@ impl ParseAttribute for InputField {
             }
 
             self.multiple = FromMeta::from_meta(mi)?;
+        } else if path.is_ident("flatten") {
+            if self.flatten.is_present() {
+                return Err(Error::duplicate_field_path(path).with_span(mi));
+            }
+
+            self.flatten = FromMeta::from_meta(mi)?;
         } else {
             return Err(Error::unknown_field_path(path).with_span(mi));
         }

--- a/core/src/options/outer_from.rs
+++ b/core/src/options/outer_from.rs
@@ -78,4 +78,8 @@ impl ParseData for OuterFrom {
             _ => self.container.parse_field(field),
         }
     }
+
+    fn validate_body(&self, errors: &mut crate::error::Accumulator) {
+        self.container.validate_body(errors);
+    }
 }

--- a/tests/compile-fail/flatten_meta_conflicts.rs
+++ b/tests/compile-fail/flatten_meta_conflicts.rs
@@ -1,0 +1,21 @@
+use darling::FromMeta;
+
+#[derive(FromMeta)]
+struct Inner {
+    left: String,
+    right: String,
+}
+
+#[derive(FromMeta)]
+struct Outer {
+    #[darling(flatten, multiple, with = demo, skip = true)]
+    field: Inner,
+}
+
+#[derive(FromMeta)]
+struct ThisIsFine {
+    #[darling(flatten, multiple = false)]
+    field: Inner,
+}
+
+fn main() {}

--- a/tests/compile-fail/flatten_meta_conflicts.stderr
+++ b/tests/compile-fail/flatten_meta_conflicts.stderr
@@ -1,0 +1,17 @@
+error: `flatten` and `multiple` cannot be used together
+  --> tests/compile-fail/flatten_meta_conflicts.rs:11:24
+   |
+11 |     #[darling(flatten, multiple, with = demo, skip = true)]
+   |                        ^^^^^^^^
+
+error: `flatten` and `with` cannot be used together
+  --> tests/compile-fail/flatten_meta_conflicts.rs:11:34
+   |
+11 |     #[darling(flatten, multiple, with = demo, skip = true)]
+   |                                  ^^^^
+
+error: `flatten` and `skip` cannot be used together
+  --> tests/compile-fail/flatten_meta_conflicts.rs:11:47
+   |
+11 |     #[darling(flatten, multiple, with = demo, skip = true)]
+   |                                               ^^^^

--- a/tests/compile-fail/flatten_multiple_fields.rs
+++ b/tests/compile-fail/flatten_multiple_fields.rs
@@ -1,0 +1,28 @@
+//! Test that multiple fields cannot be marked `flatten` at once.
+
+use darling::{FromDeriveInput, FromMeta};
+
+#[derive(FromMeta)]
+struct Inner {
+    left: String,
+    right: String,
+}
+
+#[derive(FromMeta)]
+pub struct Example {
+    #[darling(flatten)]
+    first: Inner,
+    #[darling(flatten)]
+    last: Inner,
+}
+
+#[derive(FromDeriveInput)]
+pub struct FdiExample {
+    ident: syn::Ident,
+    #[darling(flatten)]
+    first: Inner,
+    #[darling(flatten)]
+    last: Inner,
+}
+
+fn main() {}

--- a/tests/compile-fail/flatten_multiple_fields.stderr
+++ b/tests/compile-fail/flatten_multiple_fields.stderr
@@ -1,0 +1,23 @@
+error: `#[darling(flatten)]` can only be applied to one field
+  --> tests/compile-fail/flatten_multiple_fields.rs:13:15
+   |
+13 |     #[darling(flatten)]
+   |               ^^^^^^^
+
+error: `#[darling(flatten)]` can only be applied to one field
+  --> tests/compile-fail/flatten_multiple_fields.rs:15:15
+   |
+15 |     #[darling(flatten)]
+   |               ^^^^^^^
+
+error: `#[darling(flatten)]` can only be applied to one field
+  --> tests/compile-fail/flatten_multiple_fields.rs:22:15
+   |
+22 |     #[darling(flatten)]
+   |               ^^^^^^^
+
+error: `#[darling(flatten)]` can only be applied to one field
+  --> tests/compile-fail/flatten_multiple_fields.rs:24:15
+   |
+24 |     #[darling(flatten)]
+   |               ^^^^^^^

--- a/tests/flatten.rs
+++ b/tests/flatten.rs
@@ -1,0 +1,121 @@
+use darling::{util::Flag, FromDeriveInput, FromMeta};
+use proc_macro2::Ident;
+use syn::parse_quote;
+
+#[derive(FromMeta)]
+struct Vis {
+    public: Flag,
+    private: Flag,
+}
+
+#[derive(FromDeriveInput)]
+#[darling(attributes(sample))]
+struct Example {
+    ident: Ident,
+    label: String,
+    #[darling(flatten)]
+    visibility: Vis,
+}
+
+#[test]
+fn happy_path() {
+    let di = Example::from_derive_input(&parse_quote! {
+        #[sample(label = "Hello", public)]
+        struct Demo {}
+    });
+
+    let parsed = di.unwrap();
+    assert_eq!(parsed.ident, "Demo");
+    assert_eq!(&parsed.label, "Hello");
+    assert!(parsed.visibility.public.is_present());
+    assert!(!parsed.visibility.private.is_present());
+}
+
+#[test]
+fn unknown_field_errors() {
+    let errors = Example::from_derive_input(&parse_quote! {
+        #[sample(label = "Hello", republic)]
+        struct Demo {}
+    })
+    .map(|_| "Should have failed")
+    .unwrap_err();
+
+    assert_eq!(errors.len(), 1);
+}
+
+/// This test demonstrates flatten being used recursively.
+/// Fields are expected to be consumed by the outermost matching struct.
+#[test]
+fn recursive_flattening() {
+    #[derive(FromMeta)]
+    struct Nested2 {
+        above: isize,
+        below: isize,
+        port: Option<isize>,
+    }
+
+    #[derive(FromMeta)]
+    struct Nested1 {
+        port: isize,
+        starboard: isize,
+        #[darling(flatten)]
+        z_axis: Nested2,
+    }
+
+    #[derive(FromMeta)]
+    struct Nested0 {
+        fore: isize,
+        aft: isize,
+        #[darling(flatten)]
+        cross_section: Nested1,
+    }
+
+    #[derive(FromDeriveInput)]
+    #[darling(attributes(boat))]
+    struct BoatPosition {
+        #[darling(flatten)]
+        pos: Nested0,
+    }
+
+    let parsed = BoatPosition::from_derive_input(&parse_quote! {
+        #[boat(fore = 1, aft = 1, port = 10, starboard = 50, above = 20, below = -3)]
+        struct Demo;
+    })
+    .unwrap();
+
+    assert_eq!(parsed.pos.fore, 1);
+    assert_eq!(parsed.pos.aft, 1);
+
+    assert_eq!(parsed.pos.cross_section.port, 10);
+    assert_eq!(parsed.pos.cross_section.starboard, 50);
+
+    assert_eq!(parsed.pos.cross_section.z_axis.above, 20);
+    assert_eq!(parsed.pos.cross_section.z_axis.below, -3);
+    // This should be `None` because the `port` field in `Nested1` consumed
+    // the field before the leftovers were passed to `Nested2::from_list`.
+    assert_eq!(parsed.pos.cross_section.z_axis.port, None);
+}
+
+/// This test confirms that a collection - in this case a HashMap - can
+/// be used with `flatten`.
+#[test]
+fn flattening_into_hashmap() {
+    #[derive(FromDeriveInput)]
+    #[darling(attributes(ca))]
+    struct Catchall {
+        hello: String,
+        volume: usize,
+        #[darling(flatten)]
+        others: std::collections::HashMap<String, String>,
+    }
+
+    let parsed = Catchall::from_derive_input(&parse_quote! {
+        #[ca(hello = "World", volume = 10, first_name = "Alice", second_name = "Bob")]
+        struct Demo;
+    })
+    .unwrap();
+
+    assert_eq!(parsed.hello, "World");
+    assert_eq!(parsed.volume, 10);
+    assert_eq!(parsed.others.len(), 2);
+}

--- a/tests/flatten_error_accumulation.rs
+++ b/tests/flatten_error_accumulation.rs
@@ -1,0 +1,45 @@
+use darling::{util::Flag, Error, FromDeriveInput, FromMeta};
+use proc_macro2::Ident;
+use syn::parse_quote;
+
+#[derive(FromMeta)]
+#[darling(and_then = Self::validate)]
+struct Vis {
+    public: Flag,
+    private: Flag,
+}
+
+impl Vis {
+    fn validate(self) -> darling::Result<Self> {
+        if self.public.is_present() && self.private.is_present() {
+            return Err(Error::custom("Cannot be both public and private"));
+        }
+
+        Ok(self)
+    }
+}
+
+#[derive(FromDeriveInput)]
+#[darling(attributes(sample))]
+#[allow(dead_code)]
+struct Example {
+    ident: Ident,
+    label: String,
+    volume: usize,
+    #[darling(flatten)]
+    visibility: Vis,
+}
+
+#[test]
+fn many_errors() {
+    let e = Example::from_derive_input(&parse_quote! {
+        #[sample(volume = 10, public, private)]
+        struct Demo {}
+    })
+    .map(|_| "Should have failed")
+    .unwrap_err();
+
+    // We are expecting an error from the Vis::validate method and an error for the
+    // missing `label` field.
+    assert_eq!(e.len(), 2);
+}


### PR DESCRIPTION
Add support for `#[darling(flatten)]`; this does the same thing that `#[serde(flatten)]` does, removing a layer of structure in the AST representation to allow for "merging" two structs together.

Fixes #146 