### PR TITLE
Allow word-form for newtype variants if the field type supports from_none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+-  Allow word-form for newtype enum variants whose only field produces a value when `from_none` is called on their type [#249](https://github.com/TedDriggs/darling/issues/249)
+
 ## v0.20.8 (February 23, 2024)
 
 -  Add `#[darling(with = ...)]` support to `attrs` magic field to allow using custom receiver types for `attrs` [#273](https://github.com/TedDriggs/darling/issues/273)

--- a/tests/enums_newtype.rs
+++ b/tests/enums_newtype.rs
@@ -13,6 +13,7 @@ pub struct Amet {
 pub enum Lorem {
     Ipsum(bool),
     Dolor(String),
+    OptDolor(Option<String>),
     Sit(Amet),
 }
 
@@ -59,6 +60,42 @@ fn string_literal() {
 
     let pr = Holder::from_derive_input(&di).unwrap();
     assert_eq!(pr, Lorem::Dolor("Hello".to_string()));
+}
+
+#[test]
+fn option_literal() {
+    let holder = Holder::from_derive_input(&parse_quote! {
+        #[hello(lorem(opt_dolor = "Hello"))]
+        struct Bar;
+    })
+    .unwrap();
+
+    assert_eq!(holder.lorem, Lorem::OptDolor(Some("Hello".into())));
+}
+
+/// Make sure newtype variants whose field's type's `from_none` return
+/// a `Some` can be used in key-value form.
+#[test]
+fn option_word_only() {
+    let holder = Holder::from_derive_input(&parse_quote! {
+        #[hello(lorem = "opt_dolor")]
+        struct Bar;
+    })
+    .unwrap();
+
+    assert_eq!(holder.lorem, Lorem::OptDolor(None));
+}
+
+/// Make sure that newtype variants which don't produce a from_none value
+/// do not allow the word form.
+#[test]
+#[should_panic]
+fn word_only_fails_for_non_option() {
+    Holder::from_derive_input(&parse_quote! {
+        #[hello(lorem = "dolor")]
+        struct Bar;
+    })
+    .unwrap();
 }
 
 #[test]


### PR DESCRIPTION
Fixes #249