### PR TITLE
feat: add parse_attr_into

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,9 @@ This will produce a normal `darling::Result<T>` that can be used the same as a r
 ## Macro Code
 
 ```rust,ignore
-use darling::{Error, FromMeta, parse_meta};
-use darling::ast::NestedMeta;
-use syn::ItemFn;
+use darling::{parse_meta, FromMeta};
 use proc_macro::TokenStream;
+use syn::ItemFn;
 
 #[derive(Debug, FromMeta)]
 struct MacroArgs {
@@ -81,13 +80,8 @@ struct MacroArgs {
 
 #[proc_macro_attribute]
 pub fn your_attr(args: TokenStream, input: TokenStream) -> TokenStream {
-    let attr_args = parse_meta!(args as MacroArgs);
+    let _args = parse_meta!(args as MacroArgs);
     let _input = syn::parse_macro_input!(input as ItemFn);
-
-    let _args = match MacroArgs::from_list(&attr_args) {
-        Ok(v) => v,
-        Err(e) => { return TokenStream::from(e.write_errors()); }
-    };
 
     // do things with `args`
     unimplemented!()

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ This will produce a normal `darling::Result<T>` that can be used the same as a r
 ## Macro Code
 
 ```rust,ignore
-use darling::{Error, FromMeta};
+use darling::{Error, FromMeta, parse_meta};
 use darling::ast::NestedMeta;
 use syn::ItemFn;
 use proc_macro::TokenStream;
@@ -81,10 +81,7 @@ struct MacroArgs {
 
 #[proc_macro_attribute]
 pub fn your_attr(args: TokenStream, input: TokenStream) -> TokenStream {
-    let attr_args = match NestedMeta::parse_meta_list(args.into()) {
-        Ok(v) => v,
-        Err(e) => { return TokenStream::from(Error::from(e).write_errors()); }
-    };
+    let attr_args = parse_meta!(args as MacroArgs);
     let _input = syn::parse_macro_input!(input as ItemFn);
 
     let _args = match MacroArgs::from_list(&attr_args) {

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -21,3 +21,6 @@ quote = "1.0.18"
 syn = { version = "2.0.15", features = ["full", "extra-traits"] }
 fnv = "1.0.7"
 strsim = { version = "0.10.0", optional = true }
+
+[dev-dependencies]
+darling = { path = ".." }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -40,3 +40,20 @@ pub use self::from_variant::FromVariant;
 pub use quote::ToTokens;
 #[doc(hidden)]
 pub use syn;
+
+#[macro_export]
+macro_rules! parse_attr_into {
+    ($attr:ident as $ty:ty) => {
+        match $crate::ast::NestedMeta::parse_meta_list($attr.into()) {
+            Ok(v) => match <$ty as $crate::FromMeta>::from_list(&v) {
+                Ok(v) => v,
+                Err(e) => {
+                    return TokenStream::from(e.write_errors());
+                }
+            },
+            Err(e) => {
+                return TokenStream::from($crate::Error::from(e).write_errors());
+            }
+        }
+    };
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,8 +75,8 @@ pub use darling_macro::*;
 
 #[doc(inline)]
 pub use darling_core::{
-    FromAttributes, FromDeriveInput, FromField, FromGenericParam, FromGenerics, FromMeta,
-    FromTypeParam, FromVariant, parse_meta
+    parse_meta, FromAttributes, FromDeriveInput, FromField, FromGenericParam, FromGenerics,
+    FromMeta, FromTypeParam, FromVariant,
 };
 
 #[doc(inline)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@ pub use darling_macro::*;
 #[doc(inline)]
 pub use darling_core::{
     FromAttributes, FromDeriveInput, FromField, FromGenericParam, FromGenerics, FromMeta,
-    FromTypeParam, FromVariant,
+    FromTypeParam, FromVariant, parse_meta
 };
 
 #[doc(inline)]

--- a/tests/compile-success/readme_example.rs
+++ b/tests/compile-success/readme_example.rs
@@ -1,0 +1,21 @@
+extern crate proc_macro;
+use darling::{parse_meta, FromMeta};
+use proc_macro::TokenStream;
+use syn::ItemFn;
+
+#[derive(Debug, FromMeta)]
+struct MacroArgs {
+    #[darling(default)]
+    timeout_ms: Option<u16>,
+    path: String,
+}
+
+pub fn your_attr(args: TokenStream, input: TokenStream) -> TokenStream {
+    let _args = parse_meta!(args as MacroArgs);
+    let _input = syn::parse_macro_input!(input as ItemFn);
+
+    // do things with `args`
+    unimplemented!()
+}
+
+fn main() {}

--- a/tests/compiletests.rs
+++ b/tests/compiletests.rs
@@ -5,6 +5,7 @@
 fn compile_test() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/compile-fail/*.rs");
+    t.pass("tests/compile-success/*.rs");
 }
 
 #[rustversion::not(stable(1.65))]


### PR DESCRIPTION
add parse_attr_into macro, making the following code possible: 

```rust
#[derive(Debug, Default, FromMeta)]
#[darling(default)]
pub struct Attr {
    pub default: bool,
}

#[proc_macro_attribute]
pub fn api(attr: TokenStream, input: TokenStream) -> TokenStream {
    let _attr = parse_attr_into!(attr as Attr);
    input
}
```