### PR TITLE
Bump to edition 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ implementing custom derives.
 """
 license = "MIT"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 exclude = ["/.travis.yml", "/publish.sh", "/.github/**"]
 
 [badges]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -8,7 +8,7 @@ Helper crate for proc-macro library for reading attributes into structs when
 implementing custom derives. Use https://crates.io/crates/darling in your code.
 """
 license = "MIT"
-edition = "2018"
+edition = "2021"
 
 [features]
 diagnostics = []

--- a/core/src/ast/data.rs
+++ b/core/src/ast/data.rs
@@ -244,7 +244,7 @@ impl<T> Fields<T> {
         }
     }
 
-    pub fn iter(&self) -> slice::Iter<T> {
+    pub fn iter(&self) -> slice::Iter<'_, T> {
         self.fields.iter()
     }
 
@@ -428,7 +428,7 @@ impl NestedMeta {
 }
 
 impl syn::parse::Parse for NestedMeta {
-    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+    fn parse(input: syn::parse::ParseStream<'_>) -> syn::Result<Self> {
         if input.peek(syn::Lit) && !(input.peek(syn::LitBool) && input.peek2(Token![=])) {
             input.parse().map(NestedMeta::Lit)
         } else if input.peek(syn::Ident::peek_any)

--- a/core/src/ast/generics.rs
+++ b/core/src/ast/generics.rs
@@ -158,7 +158,7 @@ impl<P: FromGenericParam> FromGenerics for Generics<P> {
     }
 }
 
-pub struct TypeParams<'a, P: 'a>(Iter<'a, P>);
+pub struct TypeParams<'a, P>(Iter<'a, P>);
 
 impl<'a, P: GenericParamExt> Iterator for TypeParams<'a, P> {
     type Item = &'a <P as GenericParamExt>::TypeParam;

--- a/core/src/codegen/attr_extractor.rs
+++ b/core/src/codegen/attr_extractor.rs
@@ -13,7 +13,7 @@ pub trait ExtractAttribute {
     /// Gets the list of attribute names that should be parsed by the extractor.
     fn attr_names(&self) -> &PathList;
 
-    fn forward_attrs(&self) -> &ForwardAttrs;
+    fn forward_attrs(&self) -> &ForwardAttrs<'_>;
 
     /// Gets the name used by the generated impl to return to the `syn` item passed as input.
     fn param_name(&self) -> TokenStream;

--- a/core/src/codegen/attrs_field.rs
+++ b/core/src/codegen/attrs_field.rs
@@ -21,23 +21,23 @@ impl ForwardAttrs<'_> {
     }
 
     /// Get the field declarations to support attribute forwarding
-    pub fn as_declaration(&self) -> Option<Declaration> {
+    pub fn as_declaration(&self) -> Option<Declaration<'_>> {
         self.field.map(Declaration)
     }
 
     /// Get the match arms for attribute matching
-    pub fn as_match_arms(&self) -> MatchArms {
+    pub fn as_match_arms(&self) -> MatchArms<'_> {
         MatchArms(self)
     }
 
     /// Get the statement that will try to transform forwarded attributes into
     /// the result expected by the receiver field.
-    pub fn as_value_populator(&self) -> Option<ValuePopulator> {
+    pub fn as_value_populator(&self) -> Option<ValuePopulator<'_>> {
         self.field.map(ValuePopulator)
     }
 
     /// Get the field initializer for use when building the deriving struct.
-    pub fn as_initializer(&self) -> Option<Initializer> {
+    pub fn as_initializer(&self) -> Option<Initializer<'_>> {
         self.field.map(Initializer)
     }
 }

--- a/core/src/codegen/field.rs
+++ b/core/src/codegen/field.rs
@@ -86,7 +86,7 @@ pub struct Declaration<'a>(&'a Field<'a>);
 
 impl<'a> ToTokens for Declaration<'a> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        let field: &Field = self.0;
+        let field = self.0;
         let ident = field.ident;
         let ty = field.ty;
 
@@ -146,7 +146,7 @@ pub struct MatchArm<'a>(&'a Field<'a>);
 
 impl<'a> ToTokens for MatchArm<'a> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        let field: &Field = self.0;
+        let field = self.0;
 
         // Skipped and flattened fields cannot be populated by a meta
         // with their name, so they do not have a match arm.
@@ -211,7 +211,7 @@ pub struct Initializer<'a>(&'a Field<'a>);
 
 impl<'a> ToTokens for Initializer<'a> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        let field: &Field = self.0;
+        let field = self.0;
         let ident = field.ident;
         tokens.append_all(if field.multiple {
             if let Some(ref expr) = field.default_expression {

--- a/core/src/codegen/from_attributes_impl.rs
+++ b/core/src/codegen/from_attributes_impl.rs
@@ -79,7 +79,7 @@ impl<'a> ExtractAttribute for FromAttributesImpl<'a> {
         self.attr_names
     }
 
-    fn forward_attrs(&self) -> &super::ForwardAttrs {
+    fn forward_attrs(&self) -> &super::ForwardAttrs<'_> {
         &self.forward_attrs
     }
 

--- a/core/src/codegen/from_derive_impl.rs
+++ b/core/src/codegen/from_derive_impl.rs
@@ -116,7 +116,7 @@ impl<'a> ExtractAttribute for FromDeriveInputImpl<'a> {
         self.attr_names
     }
 
-    fn forward_attrs(&self) -> &ForwardAttrs {
+    fn forward_attrs(&self) -> &ForwardAttrs<'_> {
         &self.forward_attrs
     }
 

--- a/core/src/codegen/from_field.rs
+++ b/core/src/codegen/from_field.rs
@@ -82,7 +82,7 @@ impl<'a> ExtractAttribute for FromFieldImpl<'a> {
         self.attr_names
     }
 
-    fn forward_attrs(&self) -> &super::ForwardAttrs {
+    fn forward_attrs(&self) -> &super::ForwardAttrs<'_> {
         &self.forward_attrs
     }
 

--- a/core/src/codegen/from_type_param.rs
+++ b/core/src/codegen/from_type_param.rs
@@ -79,7 +79,7 @@ impl<'a> ExtractAttribute for FromTypeParamImpl<'a> {
         self.attr_names
     }
 
-    fn forward_attrs(&self) -> &ForwardAttrs {
+    fn forward_attrs(&self) -> &ForwardAttrs<'_> {
         &self.forward_attrs
     }
 

--- a/core/src/codegen/from_variant_impl.rs
+++ b/core/src/codegen/from_variant_impl.rs
@@ -106,7 +106,7 @@ impl<'a> ExtractAttribute for FromVariantImpl<'a> {
         self.attr_names
     }
 
-    fn forward_attrs(&self) -> &ForwardAttrs {
+    fn forward_attrs(&self) -> &ForwardAttrs<'_> {
         &self.forward_attrs
     }
 

--- a/core/src/codegen/trait_impl.rs
+++ b/core/src/codegen/trait_impl.rs
@@ -38,8 +38,8 @@ impl<'a> TraitImpl<'a> {
 
     fn type_params_matching<F, V>(&self, field_filter: F, variant_filter: V) -> IdentSet
     where
-        F: Fn(&&Field) -> bool,
-        V: Fn(&&Variant) -> bool,
+        F: Fn(&&Field<'_>) -> bool,
+        V: Fn(&&Variant<'_>) -> bool,
     {
         let declared = self.declared_type_params();
         match self.data {
@@ -67,7 +67,7 @@ impl<'a> TraitImpl<'a> {
         declared: &IdentSet,
     ) -> IdentSet
     where
-        F: Fn(&&'b Field) -> bool,
+        F: Fn(&&'b Field<'_>) -> bool,
     {
         fields
             .iter()
@@ -83,7 +83,7 @@ impl<'a> TraitImpl<'a> {
     }
 
     /// Gets the check which performs an early return if errors occurred during parsing.
-    pub fn check_errors(&self) -> ErrorCheck {
+    pub fn check_errors(&self) -> ErrorCheck<'_> {
         ErrorCheck::default()
     }
 

--- a/core/src/error/kind.rs
+++ b/core/src/error/kind.rs
@@ -64,7 +64,7 @@ impl ErrorKind {
 }
 
 impl fmt::Display for ErrorKind {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use self::ErrorKind::*;
 
         match *self {
@@ -191,7 +191,7 @@ impl<'a> From<&'a str> for ErrorUnknownField {
 }
 
 impl fmt::Display for ErrorUnknownField {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Unknown field: `{}`", self.name)?;
 
         if let Some((_, ref did_you_mean)) = self.did_you_mean {

--- a/core/src/error/mod.rs
+++ b/core/src/error/mod.rs
@@ -634,7 +634,7 @@ impl StdError for Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.kind)?;
         if !self.locations.is_empty() {
             write!(f, " at {}", self.locations.join("/"))?;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,5 +1,6 @@
 #![recursion_limit = "256"]
 #![cfg_attr(feature = "diagnostics", feature(proc_macro_diagnostic))]
+#![warn(rust_2018_idioms)]
 
 #[cfg(feature = "diagnostics")]
 extern crate proc_macro;

--- a/core/src/options/outer_from.rs
+++ b/core/src/options/outer_from.rs
@@ -43,7 +43,7 @@ impl OuterFrom {
         })
     }
 
-    pub fn as_forward_attrs(&self) -> ForwardAttrs {
+    pub fn as_forward_attrs(&self) -> ForwardAttrs<'_> {
         ForwardAttrs {
             field: self.attrs.as_ref(),
             filter: self.forward_attrs.as_ref(),

--- a/core/src/util/ident_string.rs
+++ b/core/src/util/ident_string.rs
@@ -118,13 +118,13 @@ impl ToTokens for IdentString {
 }
 
 impl fmt::Debug for IdentString {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:?}", self.ident)
     }
 }
 
 impl fmt::Display for IdentString {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.ident)
     }
 }

--- a/core/src/util/over_ride.rs
+++ b/core/src/util/over_ride.rs
@@ -126,7 +126,7 @@ impl<T> From<Option<T>> for Override<T> {
 }
 
 impl<T: fmt::Display> fmt::Display for Override<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             Inherit => write!(f, "Inherit"),
             Explicit(ref val) => write!(f, "Explicit `{}`", val),

--- a/core/src/util/parse_attribute.rs
+++ b/core/src/util/parse_attribute.rs
@@ -35,7 +35,7 @@ pub fn parse_attribute_to_meta_list(attr: &Attribute) -> Result<MetaList> {
 struct DisplayPath<'a>(&'a Path);
 
 impl fmt::Display for DisplayPath<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let path = self.0;
         if path.leading_colon.is_some() {
             write!(f, "::")?;

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -8,7 +8,7 @@ Internal support for a proc-macro library for reading attributes into structs wh
 implementing custom derives. Use https://crates.io/crates/darling in your code.
 """
 license = "MIT"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 quote = "1.0.18"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,8 +63,7 @@
 //! |`discriminant`|`Option<syn::Expr>`|For a variant such as `Example = 2`, the `2`|
 //! |`fields`|`darling::ast::Fields<T> where T: FromField`|The fields associated with the variant|
 //! |`attrs`|`Vec<syn::Attribute>` (or anything, using `#[darling(with = ...)]`)|The forwarded attributes from the passed in variant. These are controlled using the `forward_attrs` attribute.|
-
-extern crate core;
+#![warn(rust_2018_idioms)]
 
 #[allow(unused_imports)]
 #[macro_use]


### PR DESCRIPTION
This crate is still on edition 2018 but it's MSRV is exactly the MSRV needed for 2021... so let's get this over with. It turns out that there were no changes required, but I fixed all the things missed for the *2018* migration by adding `#![warn(rust_2018_idioms)]`.