### PR TITLE
Emit unwrap_or_default when appropriate for default fields

### DIFF
--- a/core/src/codegen/field.rs
+++ b/core/src/codegen/field.rs
@@ -224,15 +224,11 @@ impl<'a> ToTokens for Initializer<'a> {
                 quote!(#ident: #ident)
             }
         } else if let Some(ref expr) = field.default_expression {
-            if matches!(expr, DefaultExpression::Trait { .. }) {
-                quote_spanned!(expr.span()=> #ident: #ident.1.unwrap_or_default())
+            quote_spanned!(expr.span()=> #ident: if let Some(__val) = #ident.1 {
+                __val
             } else {
-                quote_spanned!(expr.span()=> #ident: if let Some(__val) = #ident.1 {
-                    __val
-                } else {
-                    #expr
-                })
-            }
+                #expr
+            })
         } else {
             quote!(#ident: #ident.1.expect("Uninitialized fields without defaults were already checked"))
         });

--- a/core/src/codegen/field.rs
+++ b/core/src/codegen/field.rs
@@ -224,11 +224,13 @@ impl<'a> ToTokens for Initializer<'a> {
                 quote!(#ident: #ident)
             }
         } else if let Some(ref expr) = field.default_expression {
-            quote_spanned!(expr.span()=> #ident: if let Some(__val) = #ident.1 {
-                __val
-            } else {
-                #expr
-            })
+            quote_spanned!(expr.span()=> #[allow(clippy::manual_unwrap_or_default)]
+                #ident: if let Some(__val) = #ident.1 {
+                    __val
+                } else {
+                    #expr
+                }
+            )
         } else {
             quote!(#ident: #ident.1.expect("Uninitialized fields without defaults were already checked"))
         });

--- a/core/src/codegen/field.rs
+++ b/core/src/codegen/field.rs
@@ -224,11 +224,15 @@ impl<'a> ToTokens for Initializer<'a> {
                 quote!(#ident: #ident)
             }
         } else if let Some(ref expr) = field.default_expression {
-            quote_spanned!(expr.span()=> #ident: if let Some(__val) = #ident.1 {
-                __val
+            if matches!(expr, DefaultExpression::Trait { .. }) {
+                quote_spanned!(expr.span()=> #ident: #ident.1.unwrap_or_default())
             } else {
-                #expr
-            })
+                quote_spanned!(expr.span()=> #ident: if let Some(__val) = #ident.1 {
+                    __val
+                } else {
+                    #expr
+                })
+            }
         } else {
             quote!(#ident: #ident.1.expect("Uninitialized fields without defaults were already checked"))
         });


### PR DESCRIPTION
Clippy has recently started emitting error messages like:

```
warning: if let can be simplified with `.unwrap_or_default()`
  --> simics-macro/src/init/mod.rs:16:15
   |
16 |     #[darling(default)]
   |               ^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_unwrap_or_default
help: replace it with
   |
16 ~     #[darling(default)]
17 +     /// The name of the module, used in the `MOD:NAME` expression
18 ~     pub name.unwrap_or_default())]
```

This PR just uses `unwrap_or_default` as Clippy wants and the error message goes away.