### PR TITLE
Support `#[darling(with = ...)]` on the `data` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+-  Support `#[darling(with = ...)]` on the `data` field when deriving `FromDeriveInput`. This allows the use of simpler receiver types, such as a `Vec` of enum variants.
+
 ## v0.20.10 (July 9, 2024)
 
 -  Add `#[allow(clippy::manual_unwrap_or_default)]` to all generated impls to avoid causing clippy fails in crates using `darling` [#296](https://github.com/TedDriggs/darling/pull/296)

--- a/core/src/codegen/attrs_field.rs
+++ b/core/src/codegen/attrs_field.rs
@@ -1,12 +1,12 @@
 use quote::{quote, quote_spanned, ToTokens, TokenStreamExt};
 use syn::spanned::Spanned;
 
-use crate::options::{AttrsField, ForwardAttrsFilter};
+use crate::options::{ForwardAttrsFilter, ForwardedField};
 
 #[derive(Default)]
 pub struct ForwardAttrs<'a> {
     pub filter: Option<&'a ForwardAttrsFilter>,
-    pub field: Option<&'a AttrsField>,
+    pub field: Option<&'a ForwardedField>,
 }
 
 impl ForwardAttrs<'_> {
@@ -42,7 +42,7 @@ impl ForwardAttrs<'_> {
     }
 }
 
-pub struct Declaration<'a>(pub &'a AttrsField);
+pub struct Declaration<'a>(pub &'a ForwardedField);
 
 impl ToTokens for Declaration<'_> {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
@@ -54,11 +54,11 @@ impl ToTokens for Declaration<'_> {
     }
 }
 
-pub struct ValuePopulator<'a>(pub &'a AttrsField);
+pub struct ValuePopulator<'a>(pub &'a ForwardedField);
 
 impl ToTokens for ValuePopulator<'_> {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        let AttrsField { ident, with } = self.0;
+        let ForwardedField { ident, with } = self.0;
         let initializer_expr = match with {
             Some(with) => quote_spanned!(with.span()=> __errors.handle(#with(__fwd_attrs))),
             None => quote!(::darling::export::Some(__fwd_attrs)),
@@ -67,7 +67,7 @@ impl ToTokens for ValuePopulator<'_> {
     }
 }
 
-pub struct Initializer<'a>(pub &'a AttrsField);
+pub struct Initializer<'a>(pub &'a ForwardedField);
 
 impl ToTokens for Initializer<'_> {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {

--- a/core/src/options/forward_attrs.rs
+++ b/core/src/options/forward_attrs.rs
@@ -1,49 +1,6 @@
-use proc_macro2::Ident;
-use syn::Path;
-
 use crate::ast::NestedMeta;
 use crate::util::PathList;
-use crate::{Error, FromField, FromMeta, Result};
-
-use super::ParseAttribute;
-
-/// The `attrs` magic field and attributes that influence its behavior.
-#[derive(Debug, Clone)]
-pub struct AttrsField {
-    /// The ident of the field that will receive the forwarded attributes.
-    pub ident: Ident,
-    /// Path of the function that will be called to convert the `Vec` of
-    /// forwarded attributes into the type expected by the field in `ident`.
-    pub with: Option<Path>,
-}
-
-impl FromField for AttrsField {
-    fn from_field(field: &syn::Field) -> crate::Result<Self> {
-        let result = Self {
-            ident: field.ident.clone().ok_or_else(|| {
-                Error::custom("attributes receiver must be named field").with_span(field)
-            })?,
-            with: None,
-        };
-
-        result.parse_attributes(&field.attrs)
-    }
-}
-
-impl ParseAttribute for AttrsField {
-    fn parse_nested(&mut self, mi: &syn::Meta) -> crate::Result<()> {
-        if mi.path().is_ident("with") {
-            if self.with.is_some() {
-                return Err(Error::duplicate_field_path(mi.path()).with_span(mi));
-            }
-
-            self.with = FromMeta::from_meta(mi)?;
-            Ok(())
-        } else {
-            Err(Error::unknown_field_path_with_alts(mi.path(), &["with"]).with_span(mi))
-        }
-    }
-}
+use crate::{FromMeta, Result};
 
 /// A rule about which attributes to forward to the generated struct.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/core/src/options/forwarded_field.rs
+++ b/core/src/options/forwarded_field.rs
@@ -1,0 +1,43 @@
+use syn::{Ident, Path};
+
+use crate::{Error, FromField, FromMeta};
+
+use super::ParseAttribute;
+
+/// A forwarded field and attributes that influence its behavior.
+#[derive(Debug, Clone)]
+pub struct ForwardedField {
+    /// The ident of the field that will receive the forwarded value.
+    pub ident: Ident,
+    /// Path of the function that will be called to convert the forwarded value
+    /// into the type expected by the field in `ident`.
+    pub with: Option<Path>,
+}
+
+impl FromField for ForwardedField {
+    fn from_field(field: &syn::Field) -> crate::Result<Self> {
+        let result = Self {
+            ident: field.ident.clone().ok_or_else(|| {
+                Error::custom("forwarded field must be named field").with_span(field)
+            })?,
+            with: None,
+        };
+
+        result.parse_attributes(&field.attrs)
+    }
+}
+
+impl ParseAttribute for ForwardedField {
+    fn parse_nested(&mut self, mi: &syn::Meta) -> crate::Result<()> {
+        if mi.path().is_ident("with") {
+            if self.with.is_some() {
+                return Err(Error::duplicate_field_path(mi.path()).with_span(mi));
+            }
+
+            self.with = FromMeta::from_meta(mi)?;
+            Ok(())
+        } else {
+            Err(Error::unknown_field_path_with_alts(mi.path(), &["with"]).with_span(mi))
+        }
+    }
+}

--- a/core/src/options/from_derive.rs
+++ b/core/src/options/from_derive.rs
@@ -4,7 +4,9 @@ use syn::Ident;
 
 use crate::codegen::FromDeriveInputImpl;
 use crate::options::{DeriveInputShapeSet, OuterFrom, ParseAttribute, ParseData};
-use crate::{FromMeta, Result};
+use crate::{FromField, FromMeta, Result};
+
+use super::forwarded_field::ForwardedField;
 
 #[derive(Debug)]
 pub struct FdiOptions {
@@ -16,7 +18,8 @@ pub struct FdiOptions {
     /// The field on the target struct which should receive the type generics, if any.
     pub generics: Option<Ident>,
 
-    pub data: Option<Ident>,
+    /// The field on the target struct which should receive the derive input body, if any.
+    pub data: Option<ForwardedField>,
 
     pub supports: Option<DeriveInputShapeSet>,
 }
@@ -58,7 +61,7 @@ impl ParseData for FdiOptions {
                 Ok(())
             }
             Some("data") => {
-                self.data.clone_from(&field.ident);
+                self.data = ForwardedField::from_field(field).map(Some)?;
                 Ok(())
             }
             Some("generics") => {

--- a/core/src/options/mod.rs
+++ b/core/src/options/mod.rs
@@ -7,6 +7,7 @@ use crate::{Error, FromMeta, Result};
 
 mod core;
 mod forward_attrs;
+mod forwarded_field;
 mod from_attributes;
 mod from_derive;
 mod from_field;
@@ -19,7 +20,8 @@ mod outer_from;
 mod shape;
 
 pub use self::core::Core;
-pub use self::forward_attrs::{AttrsField, ForwardAttrsFilter};
+pub use self::forward_attrs::ForwardAttrsFilter;
+pub use self::forwarded_field::ForwardedField;
 pub use self::from_attributes::FromAttributesOptions;
 pub use self::from_derive::FdiOptions;
 pub use self::from_field::FromFieldOptions;

--- a/core/src/options/outer_from.rs
+++ b/core/src/options/outer_from.rs
@@ -3,7 +3,7 @@ use syn::{Field, Ident, Meta};
 
 use crate::codegen::ForwardAttrs;
 use crate::options::{
-    AttrsField, Core, DefaultExpression, ForwardAttrsFilter, ParseAttribute, ParseData,
+    Core, DefaultExpression, ForwardAttrsFilter, ForwardedField, ParseAttribute, ParseData,
 };
 use crate::util::PathList;
 use crate::{FromField, FromMeta, Result};
@@ -16,7 +16,7 @@ pub struct OuterFrom {
     pub ident: Option<Ident>,
 
     /// The field on the target struct which should receive the type attributes, if any.
-    pub attrs: Option<AttrsField>,
+    pub attrs: Option<ForwardedField>,
 
     pub container: Core,
 
@@ -82,7 +82,7 @@ impl ParseData for OuterFrom {
                 Ok(())
             }
             Some("attrs") => {
-                self.attrs = AttrsField::from_field(field).map(Some)?;
+                self.attrs = ForwardedField::from_field(field).map(Some)?;
                 Ok(())
             }
             _ => self.container.parse_field(field),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@
 //! |`ident`|`syn::Ident`|The identifier of the passed-in type|
 //! |`vis`|`syn::Visibility`|The visibility of the passed-in type|
 //! |`generics`|`T: darling::FromGenerics`|The generics of the passed-in type. This can be `syn::Generics`, `darling::ast::Generics`, or any compatible type.|
-//! |`data`|`darling::ast::Data`|The body of the passed-in type|
+//! |`data` (or anything, using `#[darling(with = ...)]`)|`darling::ast::Data`|The body of the passed-in type|
 //! |`attrs`|`Vec<syn::Attribute>` (or anything, using `#[darling(with = ...)]`)|The forwarded attributes from the passed in type. These are controlled using the `forward_attrs` attribute.|
 //!
 //! ### `FromField`

--- a/tests/data_with.rs
+++ b/tests/data_with.rs
@@ -1,0 +1,49 @@
+use std::collections::BTreeSet;
+
+use darling::{Error, FromDeriveInput, Result};
+use syn::parse_quote;
+
+fn field_names(data: &syn::Data) -> Result<BTreeSet<String>> {
+    let fields = match data {
+        syn::Data::Struct(data) => data.fields.iter(),
+        syn::Data::Enum(_) => return Err(Error::custom("Expected struct or union")),
+        syn::Data::Union(data) => data.fields.named.iter(),
+    };
+
+    Ok(fields
+        .filter_map(|f| f.ident.clone())
+        .map(|i| i.to_string())
+        .collect())
+}
+
+#[derive(FromDeriveInput)]
+#[darling(attributes(a), forward_attrs)]
+struct Receiver {
+    #[darling(with = field_names)]
+    data: BTreeSet<String>,
+}
+
+#[test]
+fn succeeds_on_no_fields() {
+    let di = Receiver::from_derive_input(&parse_quote! {
+        struct Demo;
+    })
+    .unwrap();
+
+    assert!(di.data.is_empty());
+}
+
+#[test]
+fn succeeds_on_valid_input() {
+    let di = Receiver::from_derive_input(&parse_quote! {
+        struct Demo {
+            hello: String,
+            world: String,
+        }
+    })
+    .unwrap();
+
+    assert_eq!(di.data.len(), 2);
+    assert!(di.data.contains("hello"));
+    assert!(di.data.contains("world"));
+}


### PR DESCRIPTION
This makes the forwarded field `data` significantly more flexible, as it allows the receiver to choose whatever field type is best suited to the receiver's use-case. This also makes body validation much easier, by allowing for a `with` function that does validation after parsing.