### PR TITLE
Accept a closure for `with` in lieu of a path for fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 -  Support `#[darling(with = ...)]` on the `data` field when deriving `FromDeriveInput`. This allows the use of simpler receiver types, such as a `Vec` of enum variants.
 -  Bump version of `proc-macro2` to 1.0.86.
+-  Accept closures for `#[darling(with = ...)]` on fields in `FromDeriveInput`, `FromMeta`, `FromField`, etc. [#309](https://github.com/TedDriggs/darling/issues/309)
 
 ## v0.20.10 (July 9, 2024)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ syn = "2.0.15"
 
 [target.'cfg(compiletests)'.dev-dependencies]
 rustversion = "1.0.9"
-trybuild = "1.0.99"
+trybuild = "1.0.89"
 
 [features]
 default = ["suggestions"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ syn = "2.0.15"
 
 [target.'cfg(compiletests)'.dev-dependencies]
 rustversion = "1.0.9"
-trybuild = "1.0.38"
+trybuild = "1.0.99"
 
 [features]
 default = ["suggestions"]

--- a/compiletests.sh
+++ b/compiletests.sh
@@ -1,1 +1,1 @@
-RUSTFLAGS="--cfg=compiletests" cargo +1.65.0 test --test compiletests
+RUSTFLAGS="--cfg=compiletests" cargo +1.77.0 test --test compiletests

--- a/core/src/codegen/field.rs
+++ b/core/src/codegen/field.rs
@@ -22,6 +22,9 @@ pub struct Field<'a> {
     /// The type of the field in the input.
     pub ty: &'a Type,
     pub default_expression: Option<DefaultExpression<'a>>,
+    /// Initial declaration for `with`; this is used if `with` was a closure,
+    /// to assign the closure to a local variable.
+    pub with_initializer: Option<syn::Stmt>,
     pub with_path: Cow<'a, Path>,
     pub post_transform: Option<&'a PostfixTransform>,
     pub skip: bool,
@@ -106,6 +109,10 @@ impl<'a> ToTokens for Declaration<'a> {
             tokens.append_all(quote! {
                 let mut __flatten: Vec<::darling::ast::NestedMeta> = vec![];
             });
+        }
+
+        if let Some(stmt) = &self.0.with_initializer {
+            stmt.to_tokens(tokens);
         }
     }
 }

--- a/core/src/options/input_field.rs
+++ b/core/src/options/input_field.rs
@@ -1,6 +1,5 @@
 use std::borrow::Cow;
 
-use quote::format_ident;
 use syn::{parse_quote_spanned, spanned::Spanned};
 
 use crate::codegen;
@@ -35,8 +34,7 @@ impl InputField {
                 .map_or_else(|| Cow::Owned(self.ident.to_string()), Cow::Borrowed),
             ty: &self.ty,
             default_expression: self.as_codegen_default(),
-            with_initializer: self.with.as_ref().and_then(With::to_closure_declaration),
-            with_path: self.with.as_ref().map(|w| &w.path).map_or_else(
+            with_callable: self.with.as_ref().map(|w| &w.call).map_or_else(
                 || {
                     Cow::Owned(
                         parse_quote_spanned!(self.ty.span()=> ::darling::FromMeta::from_meta),
@@ -151,7 +149,7 @@ impl ParseAttribute for InputField {
                 return Err(Error::duplicate_field_path(path).with_span(mi));
             }
 
-            self.with = Some(With::from_meta(&self.ident, mi)?);
+            self.with = Some(With::from_meta(mi)?);
 
             if self.flatten.is_present() {
                 return Err(
@@ -244,53 +242,21 @@ impl ParseAttribute for InputField {
 
 #[derive(Debug, Clone)]
 pub struct With {
-    /// The path that generated code should use when calling this.
-    path: syn::Path,
-    /// If set, the closure that should be assigned to `path` locally.
-    closure: Option<syn::ExprClosure>,
+    /// The callable
+    call: syn::Expr,
 }
 
 impl With {
-    pub fn from_meta(field_name: &syn::Ident, meta: &syn::Meta) -> Result<Self> {
+    pub fn from_meta(meta: &syn::Meta) -> Result<Self> {
         if let syn::Meta::NameValue(nv) = meta {
             match &nv.value {
-                syn::Expr::Path(path) => Ok(Self::from(path.path.clone())),
-                syn::Expr::Closure(closure) => Ok(Self {
-                    path: format_ident!("__with_closure_for_{}", field_name).into(),
-                    closure: Some(closure.clone()),
+                syn::Expr::Path(_) | syn::Expr::Closure(_) => Ok(Self {
+                    call: nv.value.clone(),
                 }),
                 _ => Err(Error::unexpected_expr_type(&nv.value)),
             }
         } else {
             Err(Error::unsupported_format("non-value"))
-        }
-    }
-
-    /// Create the statement that declares the closure as a function pointer.
-    fn to_closure_declaration(&self) -> Option<syn::Stmt> {
-        self.closure.as_ref().map(|c| {
-            let path = &self.path;
-            // An explicit annotation that the input is borrowed is needed here,
-            // or attempting to pass a closure will fail with an issue about a temporary
-            // value being dropped while still borrowed in the extractor loop.
-            //
-            // Making the parameter type explicit here avoids errors if the closure doesn't
-            // do enough to make the type clear to the compiler.
-            //
-            // The explicit return type is needed, or else using `Ok` and `?` in the closure
-            // body will produce an error about needing type annotations due to uncertainty
-            // about the error variant's type. `T` is left undefined so that postfix transforms
-            // still work as expected
-            parse_quote_spanned!(c.span()=> let #path: fn(&::syn::Meta) -> ::darling::Result<_> = #c;)
-        })
-    }
-}
-
-impl From<syn::Path> for With {
-    fn from(path: syn::Path) -> Self {
-        Self {
-            path,
-            closure: None,
         }
     }
 }

--- a/examples/expr_with.rs
+++ b/examples/expr_with.rs
@@ -1,4 +1,4 @@
-use darling::{util::parse_expr, FromDeriveInput};
+use darling::{util::parse_expr, FromDeriveInput, FromMeta};
 use syn::{parse_quote, Expr};
 
 #[derive(FromDeriveInput)]
@@ -6,14 +6,21 @@ use syn::{parse_quote, Expr};
 pub struct Receiver {
     #[darling(with = parse_expr::preserve_str_literal, map = Some)]
     example1: Option<Expr>,
+    #[darling(
+        // A closure can be used in lieu of a path.
+        with = |m| Ok(String::from_meta(m)?.to_uppercase()),
+        default
+    )]
+    example2: String,
 }
 
 fn main() {
     let input = Receiver::from_derive_input(&parse_quote! {
-        #[demo(example1 = test::path)]
+        #[demo(example1 = test::path, example2 = "hello")]
         struct Example;
     })
     .unwrap();
 
     assert_eq!(input.example1, Some(parse_quote!(test::path)));
+    assert_eq!(input.example2, "HELLO".to_string());
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ pub use darling_core::ToTokens;
 /// of the referenced types.
 #[doc(hidden)]
 pub mod export {
-    pub use core::convert::From;
+    pub use core::convert::{identity, From};
     pub use core::default::Default;
     pub use core::option::Option::{self, None, Some};
     pub use core::result::Result::{self, Err, Ok};

--- a/tests/compile-fail/attrs_with_bad_fn.stderr
+++ b/tests/compile-fail/attrs_with_bad_fn.stderr
@@ -15,6 +15,6 @@ note: method defined here
    |     pub fn handle<T>(&mut self, result: Result<T>) -> Option<T> {
    |            ^^^^^^
 help: try wrapping the expression in `Ok`
-   |
-11 |     #[darling(with = Ok(bad_converter))]
-   |                      +++             +
+    |
+11  |     #[darling(with = Ok(bad_converter))]
+    |                      +++             +

--- a/tests/compile-fail/with_closure_capture.rs
+++ b/tests/compile-fail/with_closure_capture.rs
@@ -1,0 +1,21 @@
+use darling::{FromDeriveInput, FromMeta};
+
+#[derive(FromDeriveInput)]
+#[darling(attributes(demo))]
+pub struct Receiver {
+    example1: String,
+    #[darling(
+        // This should fail because `example1` is a local that's been captured
+        // from the `FromDeriveInput` impl. That's disallowed because exposing
+        // those internals would make any change to the derived method body a
+        // potentially-breaking change.
+        with = |m| Ok(
+            String::from_meta(m)?.to_uppercase()
+            + example1.1.as_ref().map(|s| s.as_str()).unwrap_or("")
+        ),
+        default
+    )]
+    example2: String,
+}
+
+fn main() {}

--- a/tests/compile-fail/with_closure_capture.stderr
+++ b/tests/compile-fail/with_closure_capture.stderr
@@ -1,0 +1,30 @@
+error[E0308]: mismatched types
+  --> tests/compile-fail/with_closure_capture.rs:12:16
+   |
+12 |           with = |m| Ok(
+   |                  ^ arguments to this function are incorrect
+   |  ________________|
+   | |
+13 | |             String::from_meta(m)?.to_uppercase()
+14 | |             + example1.1.as_ref().map(|s| s.as_str()).unwrap_or("")
+15 | |         ),
+   | |_________^ expected fn pointer, found closure
+   |
+   = note: expected fn pointer `for<'a> fn(&'a syn::Meta) -> Result<String, darling::Error>`
+                 found closure `{closure@$DIR/tests/compile-fail/with_closure_capture.rs:12:16: 12:19}`
+note: closures can only be coerced to `fn` types if they do not capture any variables
+  --> tests/compile-fail/with_closure_capture.rs:14:15
+   |
+14 |             + example1.1.as_ref().map(|s| s.as_str()).unwrap_or("")
+   |               ^^^^^^^^ `example1` captured here
+help: the return type of this call is `{closure@$DIR/tests/compile-fail/with_closure_capture.rs:12:16: 12:19}` due to the type of the argument passed
+  --> tests/compile-fail/with_closure_capture.rs:12:16
+   |
+12 |           with = |m| Ok(
+   |  ________________^
+13 | |             String::from_meta(m)?.to_uppercase()
+14 | |             + example1.1.as_ref().map(|s| s.as_str()).unwrap_or("")
+15 | |         ),
+   | |_________- this argument influences the return type of `{{root}}`
+note: function defined here
+  --> /rustc/aedd173a2c086e558c2b66d3743b344f977621a7/library/core/src/convert/mod.rs:104:14

--- a/tests/compile-fail/with_closure_capture.stderr
+++ b/tests/compile-fail/with_closure_capture.stderr
@@ -27,4 +27,4 @@ help: the return type of this call is `{closure@$DIR/tests/compile-fail/with_clo
 15 | |         ),
    | |_________- this argument influences the return type of `{{root}}`
 note: function defined here
-  --> /rustc/aedd173a2c086e558c2b66d3743b344f977621a7/library/core/src/convert/mod.rs:104:14
+  --> $RUST/core/src/convert/mod.rs

--- a/tests/meta_with.rs
+++ b/tests/meta_with.rs
@@ -1,0 +1,33 @@
+use darling::{util::parse_expr, FromDeriveInput, FromMeta};
+use syn::{parse_quote, Expr};
+
+#[derive(FromDeriveInput)]
+#[darling(attributes(demo))]
+pub struct Receiver {
+    #[darling(with = parse_expr::preserve_str_literal, map = Some)]
+    example1: Option<Expr>,
+    #[darling(
+        with = |m| Ok(String::from_meta(m)?.to_uppercase()),
+        map = Some
+    )]
+    example2: Option<String>,
+    // This is deliberately strange - it keeps the field name, and ignores
+    // the rest of the attribute. In normal operation, this is strongly discouraged.
+    // It's used here to verify that the parameter type is known even if it can't be
+    // inferred from usage within the closure.
+    #[darling(with = |m| Ok(m.path().clone()))]
+    example3: syn::Path,
+}
+
+#[test]
+fn handles_all_cases() {
+    let input = Receiver::from_derive_input(&parse_quote! {
+        #[demo(example1 = test::path, example2 = "hello", example3)]
+        struct Example;
+    })
+    .unwrap();
+
+    assert_eq!(input.example1, Some(parse_quote!(test::path)));
+    assert_eq!(input.example2, Some("HELLO".to_string()));
+    assert_eq!(input.example3, parse_quote!(example3));
+}


### PR DESCRIPTION
Fixes #309

This has some issues, so it's not yet ready to merge:

1. It doesn't work for all the places where `with` is used.
2. I'm not thrilled with the introduction of new locals to support this, and am wondering if there's a way to write it that better encapsulates the desired behavior.