### PR TITLE
Add `from_word` impl for structs with default

### DIFF
--- a/core/src/codegen/from_meta_impl.rs
+++ b/core/src/codegen/from_meta_impl.rs
@@ -54,6 +54,14 @@ impl<'a> ToTokens for FromMetaImpl<'a> {
                 let default = base.fallback_decl();
                 let post_transform = base.post_transform_call();
 
+                let word_impl = base.default.as_ref().and_then(|_| {
+                    Some(quote! {
+                        fn from_word() -> ::darling::Result<Self> {
+                            Ok(::darling::export::Default::default())
+                        }
+                    })
+                });
+
                 quote!(
                     fn from_list(__items: &[::darling::export::NestedMeta]) -> ::darling::Result<Self> {
 
@@ -73,6 +81,8 @@ impl<'a> ToTokens for FromMetaImpl<'a> {
                             #(#inits),*
                         }) #post_transform
                     }
+
+                    #word_impl
                 )
             }
             Data::Enum(ref variants) => {

--- a/core/src/from_meta.rs
+++ b/core/src/from_meta.rs
@@ -426,6 +426,7 @@ macro_rules! from_syn_expr_type {
 
 from_syn_expr_type!(syn::ExprArray, Array);
 from_syn_expr_type!(syn::ExprPath, Path);
+from_syn_expr_type!(syn::ExprRange, Range);
 
 /// Adapter from `syn::parse::Parse` to `FromMeta` for items that cannot
 /// be expressed in a [`syn::MetaNameValue`].


### PR DESCRIPTION
Before, the `FromMeta` derive macro did not implement `from_word` for structs which are annotated with `#[darling(default)]`, even though it could.

So now expressions like:

`#[attr(arg)]`

`#[attr(arg(arg1, arg2))]`

are possible.

The former assumes the default value, and the latter allows for specification of fields.