### PR TITLE
Add explicit implementations of `FromMeta` methods to `SpannedValue` and `Override`

### DIFF
--- a/core/src/util/over_ride.rs
+++ b/core/src/util/over_ride.rs
@@ -148,4 +148,16 @@ impl<T: FromMeta> FromMeta for Override<T> {
     fn from_value(lit: &Lit) -> Result<Self> {
         Ok(Explicit(FromMeta::from_value(lit)?))
     }
+
+    fn from_char(value: char) -> Result<Self> {
+        Ok(Explicit(FromMeta::from_char(value)?))
+    }
+
+    fn from_string(value: &str) -> Result<Self> {
+        Ok(Explicit(FromMeta::from_string(value)?))
+    }
+
+    fn from_bool(value: bool) -> Result<Self> {
+        Ok(Explicit(FromMeta::from_bool(value)?))
+    }
 }

--- a/core/src/util/spanned_value.rs
+++ b/core/src/util/spanned_value.rs
@@ -97,6 +97,24 @@ impl<T: FromMeta> FromMeta for SpannedValue<T> {
 
         Ok(Self::new(value, span))
     }
+
+    fn from_nested_meta(item: &crate::ast::NestedMeta) -> Result<Self> {
+        T::from_nested_meta(item)
+            .map(|value| Self::new(value, item.span()))
+            .map_err(|e| e.with_span(item))
+    }
+
+    fn from_value(literal: &syn::Lit) -> Result<Self> {
+        T::from_value(literal)
+            .map(|value| Self::new(value, literal.span()))
+            .map_err(|e| e.with_span(literal))
+    }
+
+    fn from_expr(expr: &syn::Expr) -> Result<Self> {
+        T::from_expr(expr)
+            .map(|value| Self::new(value, expr.span()))
+            .map_err(|e| e.with_span(expr))
+    }
 }
 
 spanned!(FromGenericParam, from_generic_param, syn::GenericParam);

--- a/tests/spanned_value.rs
+++ b/tests/spanned_value.rs
@@ -1,0 +1,112 @@
+use darling::{
+    util::{Override, SpannedValue},
+    FromAttributes,
+};
+
+use quote::quote;
+use syn::{parse::Parser, Attribute, Lit};
+
+use Override::{Explicit, Inherit};
+
+#[derive(FromAttributes, Default)]
+#[darling(attributes(test_attr))]
+struct SpannedValueOverPrimitive {
+    string: SpannedValue<String>,
+    optional_int: Option<SpannedValue<u64>>,
+    override_literal: Override<SpannedValue<Lit>>,
+    optional_override_char: Option<Override<SpannedValue<char>>>,
+}
+
+macro_rules! test_cases {
+    ($(
+        $name:ident : #[test_attr($($tok:tt)*)] => $result:ident $( {
+            string: $string:expr,
+            int: $int:expr,
+            literal: $literal:pat,
+            char: $char:expr,
+        } )?;
+    )*) => {$(
+        #[test]
+        fn $name() {
+            let quoted = quote! {
+                #[test_attr(
+                   $($tok)*
+                )]
+            };
+
+            let attrs = Attribute::parse_outer
+                .parse2(quoted)
+                .expect("failed to parse tokens as an attribute list");
+
+            let result = SpannedValueOverPrimitive::from_attributes(&attrs);
+
+            test_case_result!(result, $result $({
+                string: $string,
+                int: $int,
+                literal: $literal,
+                char: $char,
+            })?);
+        }
+    )*}
+}
+
+macro_rules! test_case_result {
+    ($value:expr, Err) => {
+        assert!($value.is_err())
+    };
+
+    ($value:expr, Ok{
+        string: $string:expr,
+        int: $int:expr,
+        literal: $literal:pat,
+        char: $char:expr,
+    }) => {{
+        let out = $value.expect("failed to parse with from_attributes");
+
+        assert_eq!(out.string.as_ref(), $string);
+        assert_eq!(out.optional_int.map(|i| *i.as_ref()), $int);
+        assert!(matches!(out.override_literal, $literal));
+        assert_eq!(
+            out.optional_override_char.map(|c| match c {
+                Inherit => Inherit,
+                Explicit(value) => Explicit(*value.as_ref()),
+            }),
+            $char
+        )
+    }};
+}
+
+test_cases! {
+    basic: #[test_attr(
+        string = "Hello",
+        optional_int = 23,
+        override_literal = "foo",
+        optional_override_char = 'c'
+    )] => Ok{
+        string: "Hello",
+        int: Some(23),
+        literal: Explicit(_),
+        char: Some(Override::Explicit('c')),
+    };
+
+    omit_optionals: #[test_attr(
+        string = "Hello",
+        override_literal = "foo",
+    )] => Ok{
+        string: "Hello",
+        int: None,
+        literal: Explicit(_),
+        char: None,
+    };
+
+    omit_overrides: #[test_attr(
+        string = "Hello",
+        override_literal,
+        optional_override_char,
+    )] => Ok{
+        string: "Hello",
+        int: None,
+        literal: Inherit,
+        char: Some(Inherit),
+    };
+}


### PR DESCRIPTION
Currently, `SpannedValue` and `Override` implement only the top-level methods. This means that, if the "low-level" methods like `from_string` are called, instead of the mid- or -top level methods like `from_value` or `from_meta`, the default behavior (an error) will be used. This was leading to errors with this structure:

```rust
#[derive(darling::FromAttributes, Debug)]
#[darling(attributes(foo))]
struct RawParsedAttr {
    long: Option<Override<SpannedValue<String>>>,
    short: Option<Override<SpannedValue<char>>>,
}
```

When parsed from `#[foo(long="bar")]`, this returns an "unexpected type string", because these types end up calling `SpannedValue::from_value` directly, causing the default behavior (an error) instead of forwarding to `String::from_value`.

Added some regression tests for this behavior.