### PR TITLE
fix: make sure to use `::darling::export` in `quote_spanned` macro usage

### DIFF
--- a/core/src/codegen/field.rs
+++ b/core/src/codegen/field.rs
@@ -183,7 +183,7 @@ impl ToTokens for MatchArm<'_> {
         // even-more-specific span, our attempt here will not overwrite that and will only cost
         // us one `if` check.
         let extractor = quote_spanned!(with_callable.span()=>
-        ::darling::export::identity::<fn(&::syn::Meta) -> ::darling::Result<_>>(#with_callable)(__inner)
+        ::darling::export::identity::<fn(&::darling::export::syn::Meta) -> ::darling::Result<_>>(#with_callable)(__inner)
             #post_transform
             .map_err(|e| e.with_span(&__inner).at(#location))
         );

--- a/tests/compile-fail/with_closure_capture.stderr
+++ b/tests/compile-fail/with_closure_capture.stderr
@@ -10,7 +10,7 @@ error[E0308]: mismatched types
 15 | |         ),
    | |_________^ expected fn pointer, found closure
    |
-   = note: expected fn pointer `for<'a> fn(&'a syn::Meta) -> Result<String, darling::Error>`
+   = note: expected fn pointer `for<'a> fn(&'a syn::attr::Meta) -> Result<String, darling::Error>`
                  found closure `{closure@$DIR/tests/compile-fail/with_closure_capture.rs:12:16: 12:19}`
 note: closures can only be coerced to `fn` types if they do not capture any variables
   --> tests/compile-fail/with_closure_capture.rs:14:15


### PR DESCRIPTION
So as it stands in v0.20.11 using the following example:

```rust
#[derive(Debug, FromMeta)]
struct Thing {
    #[darling(default)]
    thing: Option<usize>,
}
```
leads to this error on compile:
```
error[E0433]: failed to resolve: could not find `syn` in the list of imported crates
  --> src/lib.rs:10:12
   |
10 |     thing: Option<usize>,
   |            ^^^^^^ could not find `syn` in the list of imported crates
```
With the suggested fix this goes away.
