### PR TITLE
Add `PreservedStrExpr` utility wrapper

### DIFF
--- a/core/src/util/mod.rs
+++ b/core/src/util/mod.rs
@@ -12,6 +12,7 @@ mod path_to_string;
 mod shape;
 mod spanned_value;
 mod with_original;
+mod preserved_str_expr;
 
 pub use self::callable::Callable;
 pub use self::flag::Flag;
@@ -21,6 +22,7 @@ pub use self::over_ride::Override;
 pub use self::parse_attribute::parse_attribute_to_meta_list;
 pub use self::path_list::PathList;
 pub use self::path_to_string::path_to_string;
+pub use self::preserved_str_expr::PreservedStrExpr;
 pub use self::shape::{AsShape, Shape, ShapeSet};
 pub use self::spanned_value::SpannedValue;
 pub use self::with_original::WithOriginal;

--- a/core/src/util/mod.rs
+++ b/core/src/util/mod.rs
@@ -9,10 +9,10 @@ mod parse_attribute;
 pub mod parse_expr;
 mod path_list;
 mod path_to_string;
+mod preserved_str_expr;
 mod shape;
 mod spanned_value;
 mod with_original;
-mod preserved_str_expr;
 
 pub use self::callable::Callable;
 pub use self::flag::Flag;

--- a/core/src/util/preserved_str_expr.rs
+++ b/core/src/util/preserved_str_expr.rs
@@ -1,0 +1,64 @@
+use crate::{FromMeta, Result};
+use syn::Expr;
+
+/// A wrapper around [`Expr`] that preserves the original expression
+/// without evaluating it.
+///
+/// For compatibility reasons, `darling` evaluates the expression inside string
+/// literals, which might be undesirable. In many cases,
+/// [`darling::util::parse_expr::preserve_str_literal`] can be used. However,
+/// when using [`Expr`] inside a container (such as a
+/// [`HashMap`](std::collections::HashMap)), it is not possible to use it.
+///
+/// This wrapper preserves the original expression without evaluating it.
+///
+/// # Example
+///
+/// ```ignore
+/// #[derive(FromMeta)]
+/// #[darling(attributes(demo))]
+/// struct Demo {
+///     option: Option<HashMap<syn::Ident, PreservedStrExpr>>,
+/// }
+/// ```
+#[repr(transparent)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct PreservedStrExpr(pub Expr);
+
+impl FromMeta for PreservedStrExpr {
+    fn from_expr(expr: &Expr) -> Result<Self> {
+        Ok(Self(expr.clone()))
+    }
+}
+
+impl From<Expr> for PreservedStrExpr {
+    fn from(value: Expr) -> Self {
+        Self(value)
+    }
+}
+
+impl From<PreservedStrExpr> for Expr {
+    fn from(value: PreservedStrExpr) -> Self {
+        value.0
+    }
+}
+
+impl quote::ToTokens for PreservedStrExpr {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        self.0.to_tokens(tokens);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::{parse_quote, Meta, MetaNameValue};
+
+    #[test]
+    fn preserved_str_expr_from_meta() {
+        let name_value: MetaNameValue = parse_quote!(test = "Hello, world!");
+        let preserved = PreservedStrExpr::from_meta(&Meta::NameValue(name_value)).unwrap();
+
+        assert_eq!(preserved.0, parse_quote!("Hello, world!"));
+    }
+}


### PR DESCRIPTION
By default, `darling` evaluates the expression inside string literals. This can be worked around with `preserve_str_literal`, but sometimes it's difficult—for instance, when a struct contains `HashMap<syn::Ident, syn::Expr>`.

This commit introduces a utility wrapper over `syn::Expr` that has a simple `FromMeta` impl that just copies the inner `Expr` instance. It can be then used like so:

```rust
#[derive(FromMeta)]
#[darling(attributes(demo))]
struct Demo {
    option: Option<HashMap<syn::Ident, PreservedStrExpr>>,
}
```