### PR TITLE
Add `syn::parse::Parse` support for `FromMeta` derive macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,7 @@ struct MacroArgs {
 
 #[proc_macro_attribute]
 pub fn your_attr(args: TokenStream, input: TokenStream) -> TokenStream {
-    let attr_args = match NestedMeta::parse_meta_list(args.into()) {
-        Ok(v) => v,
-        Err(e) => { return TokenStream::from(Error::from(e).write_errors()); }
-    };
+    let attr_args: MacroArgs = syn::parse2(args.into())?;
     let _input = syn::parse_macro_input!(input as ItemFn);
 
     let _args = match MacroArgs::from_list(&attr_args) {

--- a/README.md
+++ b/README.md
@@ -81,13 +81,8 @@ struct MacroArgs {
 
 #[proc_macro_attribute]
 pub fn your_attr(args: TokenStream, input: TokenStream) -> TokenStream {
-    let attr_args: MacroArgs = syn::parse2(args.into())?;
+    let _args: MacroArgs = syn::parse2(args.into())?;
     let _input = syn::parse_macro_input!(input as ItemFn);
-
-    let _args = match MacroArgs::from_list(&attr_args) {
-        Ok(v) => v,
-        Err(e) => { return TokenStream::from(e.write_errors()); }
-    };
 
     // do things with `args`
     unimplemented!()

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ struct MacroArgs {
 
 #[proc_macro_attribute]
 pub fn your_attr(args: TokenStream, input: TokenStream) -> TokenStream {
-    let _args: MacroArgs = match syn::parse2(args.into()) {
+    let _args: MacroArgs = match syn::parse(args) {
         Ok(v) => v,
         Err(e) => { return e.to_compile_error().into(); }
     };

--- a/README.md
+++ b/README.md
@@ -81,7 +81,10 @@ struct MacroArgs {
 
 #[proc_macro_attribute]
 pub fn your_attr(args: TokenStream, input: TokenStream) -> TokenStream {
-    let _args: MacroArgs = syn::parse2(args.into())?;
+    let _args: MacroArgs = match syn::parse2(args.into()) {
+        Ok(v) => v,
+        Err(e) => { return e.to_compile_error().into(); }
+    };
     let _input = syn::parse_macro_input!(input as ItemFn);
 
     // do things with `args`

--- a/core/src/codegen/from_meta_impl.rs
+++ b/core/src/codegen/from_meta_impl.rs
@@ -1,11 +1,10 @@
 use std::borrow::Cow;
 
 use proc_macro2::TokenStream;
-use quote::{quote, quote_spanned, ToTokens, TokenStreamExt as _};
+use quote::{quote, quote_spanned, ToTokens};
 use syn::spanned::Spanned;
 
 use crate::ast::{Data, Fields, Style};
-use crate::codegen::outer_from_impl::compute_impl_bounds;
 use crate::codegen::{Field, OuterFromImpl, TraitImpl, Variant};
 use crate::util::Callable;
 
@@ -153,6 +152,7 @@ impl ToTokens for FromMetaImpl<'_> {
         };
 
         self.wrap(impl_block, tokens);
+        ParseImpl(self).to_tokens(tokens);
     }
 }
 
@@ -164,39 +164,40 @@ impl<'a> OuterFromImpl<'a> for FromMetaImpl<'a> {
     fn base(&'a self) -> &'a TraitImpl<'a> {
         &self.base
     }
+}
 
-    fn wrap<T: ToTokens>(&'a self, body: T, tokens: &mut TokenStream) {
-        let base = self.base();
-        let trayt = self.trait_path();
-        let ty_ident = base.ident;
-        // The type parameters used in non-skipped, non-magic fields.
-        // These must impl `FromMeta` unless they have custom bounds.
-        let used = base.used_type_params();
-        let generics = compute_impl_bounds(self.trait_bound(), base.generics.clone(), &used);
-        let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+struct ParseImpl<'a>(&'a FromMetaImpl<'a>);
 
-        tokens.append_all(quote!(
-            #[automatically_derived]
-            #[allow(clippy::manual_unwrap_or_default)]
-            impl #impl_generics #trayt for #ty_ident #ty_generics
-                #where_clause
-            {
-                #body
+impl<'a> OuterFromImpl<'a> for ParseImpl<'a> {
+    fn trait_path(&self) -> syn::Path {
+        path!(::darling::export::syn::parse::Parse)
+    }
+
+    fn base(&'a self) -> &'a TraitImpl<'a> {
+        &self.0.base
+    }
+
+    fn trait_bound(&self) -> syn::Path {
+        // Since the Parse impl delegates to FromMeta, that's the
+        // trait bound we need to apply.
+        self.0.trait_path()
+    }
+}
+
+impl ToTokens for ParseImpl<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let from_meta = self.0.trait_path();
+        let impl_block = quote! {
+            fn parse(input: ::darling::export::syn::parse::ParseStream<'_>) -> ::darling::export::syn::Result<Self> {
+                use ::darling::export::IntoIterator;
+
+                let items = ::darling::export::syn::punctuated::Punctuated::<::darling::export::NestedMeta, ::darling::export::syn::Token![,]>::parse_terminated(input)?
+                    .into_iter()
+                    .collect::<::darling::export::Vec<_>>();
+                <Self as #from_meta>::from_list(&items).map_err(::darling::export::Into::into)
             }
+        };
 
-            #[automatically_derived]
-            impl #impl_generics ::darling::export::syn::parse::Parse for #ty_ident #ty_generics
-                #where_clause
-            {
-                fn parse(input: ::darling::export::syn::parse::ParseStream<'_>) -> ::darling::export::syn::Result<Self> {
-                    use ::core::iter::IntoIterator;
-
-                    let items = ::darling::export::syn::punctuated::Punctuated::<::darling::export::NestedMeta, ::darling::export::syn::Token![,]>::parse_terminated(input)?
-                        .into_iter()
-                        .collect::<::darling::export::Vec<_>>();
-                    <Self as #trayt>::from_list(&items).map_err(::core::convert::Into::into)
-                }
-            }
-        ));
+        self.wrap(impl_block, tokens);
     }
 }

--- a/core/src/codegen/outer_from_impl.rs
+++ b/core/src/codegen/outer_from_impl.rs
@@ -38,7 +38,11 @@ pub trait OuterFromImpl<'a> {
     }
 }
 
-fn compute_impl_bounds(bound: Path, mut generics: Generics, applies_to: &IdentSet) -> Generics {
+pub(super) fn compute_impl_bounds(
+    bound: Path,
+    mut generics: Generics,
+    applies_to: &IdentSet,
+) -> Generics {
     if generics.params.is_empty() {
         return generics;
     }

--- a/core/src/codegen/outer_from_impl.rs
+++ b/core/src/codegen/outer_from_impl.rs
@@ -38,11 +38,7 @@ pub trait OuterFromImpl<'a> {
     }
 }
 
-pub(super) fn compute_impl_bounds(
-    bound: Path,
-    mut generics: Generics,
-    applies_to: &IdentSet,
-) -> Generics {
+fn compute_impl_bounds(bound: Path, mut generics: Generics, applies_to: &IdentSet) -> Generics {
     if generics.params.is_empty() {
         return generics;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,8 +102,9 @@ pub use darling_core::ToTokens;
 /// of the referenced types.
 #[doc(hidden)]
 pub mod export {
-    pub use core::convert::{identity, From};
+    pub use core::convert::{identity, From, Into};
     pub use core::default::Default;
+    pub use core::iter::IntoIterator;
     pub use core::option::Option::{self, None, Some};
     pub use core::result::Result::{self, Err, Ok};
     pub use darling_core::syn;

--- a/tests/from_meta.rs
+++ b/tests/from_meta.rs
@@ -65,6 +65,17 @@ fn nested_meta_lit_bool_errors() {
     );
 }
 
+#[test]
+fn parse_impl() {
+    let meta = parse_quote! {
+        meta1 = "thefeature",
+        meta2
+    };
+    let parsed_meta: Meta = syn::parse2(meta).unwrap();
+    assert_eq!(parsed_meta.meta1, Some("thefeature".to_string()));
+    assert!(parsed_meta.meta2);
+}
+
 /// Tests behavior of FromMeta implementation for enums.
 mod enum_impl {
     use darling::{Error, FromMeta};


### PR DESCRIPTION
This is taken from #349 , as I accidentally broke it.

Closes https://github.com/TedDriggs/darling/issues/285

With the syn::parse::Parse, when implement #[proc_macro_attribute], the args parsing can be simplified to

```rust
use darling::{Error, FromMeta};
use darling::ast::NestedMeta;
use syn::ItemFn;
use proc_macro::TokenStream;

#[derive(Debug, FromMeta)]
struct MacroArgs {
    #[darling(default)]
    timeout_ms: Option<u16>,
    path: String,
}

#[proc_macro_attribute]
pub fn your_attr(args: TokenStream, input: TokenStream) -> TokenStream {
    let _args: MacroArgs = match syn::parse(args) {
        Ok(v) => v,
        Err(e) => { return e.to_compile_error().into(); }
    };
    let _input = syn::parse_macro_input!(input as ItemFn);

    // do things with `args`
    unimplemented!()
}
```