### PR TITLE
List possible values for enums

### DIFF
--- a/core/src/from_meta.rs
+++ b/core/src/from_meta.rs
@@ -951,7 +951,7 @@ mod tests {
         assert_eq!(fm::<f64>(quote!(ignore = "1.4e10")), 1.4e10);
     }
 
-    #[should_panic(expected = "UnknownValue(\"0\")")]
+    #[should_panic(expected = "UnknownValue")]
     #[test]
     fn nonzero_number_fails() {
         fm::<NonZeroU64>(quote!(ignore = "0"));


### PR DESCRIPTION
This collects alternate values for unit enum variants, the same as is done for fields and value-carrying variants currently.

Fixes #362 