### PR TITLE
Accumulate all errors, including those from generics and derive-input body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+-  Keep parsing the body and type params even if there are errors from parsing attributes. [#7](https://github.com/TedDriggs/darling/issues/325)
+-  Support `#[darling(with = ...)]` on the `generics` field when deriving `FromDeriveInput`.
+
+
 ## v0.21.1 (August 4, 2025)
 
 -  Track all alternate field names, and show them in error message if there aren't too many. [#325](https://github.com/TedDriggs/darling/issues/325)

--- a/core/src/codegen/attrs_field.rs
+++ b/core/src/codegen/attrs_field.rs
@@ -37,8 +37,8 @@ impl ForwardAttrs<'_> {
     }
 
     /// Get the field initializer for use when building the deriving struct.
-    pub fn as_initializer(&self) -> Option<Initializer<'_>> {
-        self.field.map(Initializer)
+    pub fn as_initializer<'a>(&'a self) -> Option<impl 'a + ToTokens> {
+        self.field.map(|f| f.as_initializer())
     }
 }
 
@@ -64,15 +64,6 @@ impl ToTokens for ValuePopulator<'_> {
             None => quote!(::darling::export::Some(__fwd_attrs)),
         };
         tokens.append_all(quote!(#ident = #initializer_expr;));
-    }
-}
-
-pub struct Initializer<'a>(pub &'a ForwardedField);
-
-impl ToTokens for Initializer<'_> {
-    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        let ident = &self.0.ident;
-        tokens.append_all(quote!(#ident: #ident.expect("Errors were already checked"),));
     }
 }
 

--- a/core/src/options/from_derive.rs
+++ b/core/src/options/from_derive.rs
@@ -16,7 +16,7 @@ pub struct FdiOptions {
     pub vis: Option<Ident>,
 
     /// The field on the target struct which should receive the type generics, if any.
-    pub generics: Option<Ident>,
+    pub generics: Option<ForwardedField>,
 
     /// The field on the target struct which should receive the derive input body, if any.
     pub data: Option<ForwardedField>,
@@ -65,7 +65,7 @@ impl ParseData for FdiOptions {
                 Ok(())
             }
             Some("generics") => {
-                self.generics.clone_from(&field.ident);
+                self.generics = ForwardedField::from_field(field).map(Some)?;
                 Ok(())
             }
             _ => self.base.parse_field(field),

--- a/tests/accrue_errors.rs
+++ b/tests/accrue_errors.rs
@@ -37,7 +37,10 @@ fn bad_type_and_missing_fields() {
     let s_result: ::darling::Error = Lorem::from_derive_input(&input).unwrap_err();
     let err = s_result.flatten();
     println!("{}", err);
-    assert_eq!(3, err.len());
+    //   3  errors from the struct-level `accrue` attribute
+    // + 1  for the field `foo` missing `aliased_as`
+    // = 4  total errors
+    assert_eq!(4, err.len());
 }
 
 #[test]

--- a/tests/generics_with.rs
+++ b/tests/generics_with.rs
@@ -1,0 +1,77 @@
+use std::collections::BTreeSet;
+
+use darling::{Error, FromDeriveInput, Result};
+use syn::{parse_quote, Ident};
+
+fn check_ident(ident: &Ident) -> Result<String> {
+    let s = ident.to_string();
+    if s.len() < 2 {
+        Err(Error::custom("generics must be at least 2 characters").with_span(ident))
+    } else {
+        Ok(s)
+    }
+}
+
+fn long_generic_names(generics: &syn::Generics) -> Result<BTreeSet<String>> {
+    let mut errors = Error::accumulator();
+    let valid = generics
+        .type_params()
+        .filter_map(|c| errors.handle(check_ident(&c.ident)))
+        .collect();
+    errors.finish_with(valid)
+}
+
+#[derive(Debug, FromDeriveInput)]
+#[darling(attributes(a))]
+struct Receiver {
+    #[darling(with = long_generic_names)]
+    generics: BTreeSet<String>,
+    surname: String,
+}
+
+#[test]
+fn succeeds_on_no_generics() {
+    let di = Receiver::from_derive_input(&parse_quote! {
+        #[a(surname = "Smith")]
+        struct Demo;
+    })
+    .unwrap();
+
+    assert!(di.generics.is_empty());
+}
+
+#[test]
+fn succeeds_on_valid_generics() {
+    let di = Receiver::from_derive_input(&parse_quote! {
+        #[a(surname = "Smith")]
+        struct Demo<Greeting> {
+            hello: Greeting,
+            world: String,
+        }
+    })
+    .unwrap();
+
+    assert_eq!(di.generics.len(), 1);
+    assert!(di.generics.contains("Greeting"));
+    assert_eq!(di.surname, "Smith");
+}
+
+#[test]
+fn rejects_invalid_input() {
+    let err = Receiver::from_derive_input(&parse_quote! {
+        struct Demo<G, S> {
+            hello: G,
+            world: S,
+        }
+    })
+    .unwrap_err();
+
+    assert_eq!(
+        err.len(),
+        // 2 errors from short type param names
+        2 +
+        // error for missing field `surname`
+        1,
+        "errors should have accumulated, and body checking should have occurred"
+    );
+}


### PR DESCRIPTION
In principle, `darling` tries to find as many errors as it can each time it's invoked; this is consistent with how `rustc`, and `clippy` behave, and is much more pleasant to use as a developer than a system that only returns one error at a time.

When using the "magic" fields, such as `data` and `generics`, generated impls of `FromDeriveInput` weren't living up to this principle - if any errors were found when parsing meta-items, the macro would return without having done the parsing of the `data` and `generics` fields. Someone using a derived `FromDeriveInput` impl would therefore fix an error with one of their attributes, thinking they were done, only to get a new error from one of their fields.

This PR addresses that by moving the reading and validation of these magic fields earlier in the derived method body. This ensures that their errors will be caught by the accumulator, and that these will be processed regardless of any other errors encountered.

Fixes #7 