### PR TITLE
Expose `from_expr` option when deriving `FromMeta`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 -  Keep parsing the body and type params even if there are errors from parsing attributes. [#7](https://github.com/TedDriggs/darling/issues/325)
 -  Support `#[darling(with = ...)]` on the `generics` field when deriving `FromDeriveInput`.
+-  Add `#[darling(from_expr = ...)]` when deriving `FromMeta` to support overriding the key-value form [#369](https://github.com/TedDriggs/darling/issues/369)
 
 
 ## v0.21.1 (August 4, 2025)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ implementing custom derives.
 license = "MIT"
 readme = "README.md"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.56.0"
 exclude = ["/.travis.yml", "/publish.sh", "/.github/**"]
 
 [badges]

--- a/core/src/codegen/from_meta_impl.rs
+++ b/core/src/codegen/from_meta_impl.rs
@@ -12,6 +12,7 @@ pub struct FromMetaImpl<'a> {
     pub base: TraitImpl<'a>,
     pub from_word: Option<Cow<'a, Callable>>,
     pub from_none: Option<&'a Callable>,
+    pub from_expr: Option<&'a Callable>,
     pub derive_syn_parse: bool,
 }
 
@@ -31,6 +32,14 @@ impl ToTokens for FromMetaImpl<'_> {
             quote_spanned! {body.span()=>
                 fn from_none() -> ::darling::export::Option<Self> {
                     ::darling::export::identity::<fn() -> ::darling::export::Option<Self>>(#body)()
+                }
+            }
+        });
+
+        let from_expr = self.from_expr.map(|body| {
+            quote_spanned! {body.span()=>
+                fn from_expr(expr: &::darling::export::syn::Expr) -> ::darling::Result<Self> {
+                    ::darling::export::identity::<fn(&::darling::export::syn::Expr) -> ::darling::Result<Self>>(#body)(expr)
                 }
             }
         });
@@ -81,6 +90,8 @@ impl ToTokens for FromMetaImpl<'_> {
                     #from_word
 
                     #from_none
+
+                    #from_expr
 
                     fn from_list(__items: &[::darling::export::NestedMeta]) -> ::darling::Result<Self> {
 
@@ -157,6 +168,8 @@ impl ToTokens for FromMetaImpl<'_> {
                     #from_word
 
                     #from_none
+
+                    #from_expr
                 )
             }
         };

--- a/core/src/options/input_variant.rs
+++ b/core/src/options/input_variant.rs
@@ -20,6 +20,10 @@ pub struct InputVariant {
 }
 
 impl InputVariant {
+    pub fn is_unit_variant(&self) -> bool {
+        self.data.is_unit()
+    }
+
     pub fn as_codegen_variant<'a>(&'a self, ty_ident: &'a syn::Ident) -> codegen::Variant<'a> {
         codegen::Variant {
             ty_ident,

--- a/examples/from_word_and_expr.rs
+++ b/examples/from_word_and_expr.rs
@@ -1,0 +1,58 @@
+use darling::{ast::Data, util::Flag, FromDeriveInput, FromMeta};
+use darling_macro::FromField;
+
+#[derive(Default, FromMeta)]
+#[darling(from_word = || Ok(Default::default()), from_expr = |expr| Ok(ErrorPolicy::from(expr)))]
+struct ErrorPolicy {
+    warn: Flag,
+    value: Option<syn::Expr>,
+}
+
+impl From<&'_ syn::Expr> for ErrorPolicy {
+    fn from(expr: &'_ syn::Expr) -> Self {
+        ErrorPolicy {
+            warn: Flag::default(),
+            value: Some(expr.clone()),
+        }
+    }
+}
+
+#[derive(FromField)]
+#[darling(attributes(toml))]
+struct Field {
+    default: Option<ErrorPolicy>,
+    recover: Option<ErrorPolicy>,
+}
+
+#[derive(FromDeriveInput)]
+#[darling(attributes(toml))]
+struct TomlConfig {
+    data: Data<(), Field>,
+}
+
+fn main() {
+    let input = TomlConfig::from_derive_input(&syn::parse_quote! {
+        struct Config {
+            #[toml(default, recover(warn))]
+            field1: String,
+            #[toml(default = String::new())]
+            field2: String,
+        }
+    })
+    .unwrap();
+
+    assert!(input.data.is_struct());
+    let fields = input.data.take_struct().expect("input is struct").fields;
+    assert!(fields[0].default.is_some());
+    assert!(fields[0]
+        .recover
+        .as_ref()
+        .map(|r| r.warn.is_present())
+        .unwrap_or(false));
+    assert!(fields[1]
+        .default
+        .as_ref()
+        .map(|d| d.value.is_some())
+        .unwrap_or(false));
+    assert!(fields[1].recover.is_none());
+}

--- a/tests/compile-fail/from_expr.rs
+++ b/tests/compile-fail/from_expr.rs
@@ -1,0 +1,32 @@
+use darling::FromMeta;
+
+/// This usage of `from_expr` is VALID because there are no unit variants that should conflict with the
+/// implementation.
+#[derive(FromMeta)]
+#[darling(from_expr = |expr| Ok(HasNoUnits::Variant2 { other: format!("{:?}", expr) }))]
+enum HasNoUnits {
+    Variant1 { field: String },
+    Variant2 { other: String },
+}
+
+/// This usage of `from_expr` is invalid because unit variants already generate a from_expr
+/// method, and we don't allow using the from_expr override when it conflicts with the macro's
+/// "normal" operation.
+#[derive(FromMeta)]
+#[darling(from_expr = |expr| Ok(HasUnits::Variant2))]
+enum HasUnits {
+    Variant1 { field: String },
+    Variant2,
+}
+
+fn newtype_from_expr(_expr: &syn::Expr) -> darling::Result<Newtype> {
+    Ok(Newtype(true))
+}
+
+// This usage of `from_expr` is invalid because newtype structs call the inner type's `from_meta`
+// directly from their `from_meta`, so the custom `from_expr` will never be called in normal usage.
+#[derive(FromMeta)]
+#[darling(from_expr = newtype_from_expr)]
+struct Newtype(bool);
+
+fn main() {}

--- a/tests/compile-fail/from_expr.stderr
+++ b/tests/compile-fail/from_expr.stderr
@@ -1,0 +1,11 @@
+error: `from_expr` cannot be used on enums with unit variants because it conflicts with the generated impl
+  --> tests/compile-fail/from_expr.rs:16:23
+   |
+16 | #[darling(from_expr = |expr| Ok(HasUnits::Variant2))]
+   |                       ^
+
+error: `from_expr` cannot be used on newtype structs because the implementation is entirely delegated to the inner type
+  --> tests/compile-fail/from_expr.rs:29:23
+   |
+29 | #[darling(from_expr = newtype_from_expr)]
+   |                       ^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This allows the use of `from_expr` as a means of controlling the key-value syntax behavior. The new property has defensive checks that prevent its use when it collides with other generated impls, e.g. from enums with unit variant arms.

Fixes #369 
