### PR TITLE
Remove fnv

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -21,7 +21,6 @@ proc-macro2 = "1.0.86"
 quote = "1.0.18"
 serde = { version = "1.0.210", optional = true }
 syn = { version = "2.0.15", features = ["full", "extra-traits"] }
-fnv = "1.0.7"
 strsim = { version = "0.11.1", optional = true }
 
 [dev-dependencies]

--- a/core/src/usage/ident_set.rs
+++ b/core/src/usage/ident_set.rs
@@ -1,8 +1,9 @@
-use fnv::FnvHashSet;
+use std::collections::HashSet;
+
 use syn::Ident;
 
 /// A set of idents.
-pub type IdentSet = FnvHashSet<Ident>;
+pub type IdentSet = HashSet<Ident>;
 
 /// A set of references to idents.
-pub type IdentRefSet<'a> = FnvHashSet<&'a Ident>;
+pub type IdentRefSet<'a> = HashSet<&'a Ident>;

--- a/core/src/usage/lifetimes.rs
+++ b/core/src/usage/lifetimes.rs
@@ -1,14 +1,15 @@
-use fnv::FnvHashSet;
+use std::collections::HashSet;
+
 use syn::punctuated::Punctuated;
 use syn::{Lifetime, Type};
 
 use crate::usage::Options;
 
 /// A set of lifetimes.
-pub type LifetimeSet = FnvHashSet<Lifetime>;
+pub type LifetimeSet = HashSet<Lifetime>;
 
 /// A set of references to lifetimes.
-pub type LifetimeRefSet<'a> = FnvHashSet<&'a Lifetime>;
+pub type LifetimeRefSet<'a> = HashSet<&'a Lifetime>;
 
 /// Searcher for finding lifetimes in a syntax tree.
 /// This can be used to determine which lifetimes must be emitted in generated code.


### PR DESCRIPTION
`fnv` for use in `HashSet`s was added in #40, over 7 years ago, with no real justification.
This library is made for proc-macros where runtime performance doesn't matter as much, considering it will likely run in debug mode.

Remove `fnv` in favor of just using the standard library `HashSet` to remove a dependency.
This is a very small breaking change.