### PR TITLE
Add support for closure as argument to `default`

### DIFF
--- a/core/src/codegen/default_expr.rs
+++ b/core/src/codegen/default_expr.rs
@@ -1,6 +1,6 @@
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, quote_spanned, ToTokens, TokenStreamExt};
-use syn::{spanned::Spanned, Ident, Path};
+use syn::{spanned::Spanned, ExprClosure, Ident, Path};
 
 /// This will be in scope during struct initialization after option parsing.
 const DEFAULT_STRUCT_NAME: &str = "__default";
@@ -11,7 +11,10 @@ pub enum DefaultExpression<'a> {
     /// Only valid on fields, `Inherit` indicates that the value should be taken from a pre-constructed
     /// fallback object. The value in the variant is the ident of the field.
     Inherit(&'a Ident),
-    Explicit(&'a Path),
+    /// `default = path::to::function` or `default = "path::to::function"`.
+    ExplicitPath(&'a Path),
+    /// `default = || default_val()` or `default = "|| default_val()"`.
+    ExplicitClosure(&'a ExprClosure),
     Trait {
         span: Span,
     },
@@ -30,9 +33,12 @@ impl ToTokens for DefaultExpression<'_> {
                 let dsn = Ident::new(DEFAULT_STRUCT_NAME, ::proc_macro2::Span::call_site());
                 quote!(#dsn.#ident)
             }
-            DefaultExpression::Explicit(path) => {
+            DefaultExpression::ExplicitPath(path) => {
                 // Use quote_spanned to properly set the span of the parentheses
                 quote_spanned!(path.span()=>#path())
+            }
+            DefaultExpression::ExplicitClosure(closure) => {
+                quote_spanned!(closure.span()=> (#closure)())
             }
             DefaultExpression::Trait { span } => {
                 quote_spanned!(span=> ::darling::export::Default::default())

--- a/core/src/from_meta.rs
+++ b/core/src/from_meta.rs
@@ -450,6 +450,7 @@ macro_rules! from_syn_expr_type {
 }
 
 from_syn_expr_type!(syn::ExprArray, Array);
+from_syn_expr_type!(syn::ExprClosure, Closure);
 from_syn_expr_type!(syn::ExprPath, Path);
 from_syn_expr_type!(syn::ExprRange, Range);
 

--- a/core/src/options/core.rs
+++ b/core/src/options/core.rs
@@ -150,9 +150,7 @@ impl ParseData for Core {
         match self.data {
             Data::Struct(Fields {
                 style: Style::Unit, ..
-            }) => {
-                panic!("Core::parse_field should not be called on unit")
-            }
+            }) => panic!("Core::parse_field should not be called on unit"),
             Data::Struct(Fields { ref mut fields, .. }) => {
                 fields.push(f);
                 Ok(())

--- a/core/src/options/core.rs
+++ b/core/src/options/core.rs
@@ -66,7 +66,12 @@ impl Core {
 
     fn as_codegen_default(&self) -> Option<codegen::DefaultExpression<'_>> {
         self.default.as_ref().map(|expr| match *expr {
-            DefaultExpression::Explicit(ref path) => codegen::DefaultExpression::Explicit(path),
+            DefaultExpression::ExplicitPath(ref path) => {
+                codegen::DefaultExpression::ExplicitPath(path)
+            }
+            DefaultExpression::ExplicitClosure(ref closure) => {
+                codegen::DefaultExpression::ExplicitClosure(closure)
+            }
             DefaultExpression::Inherit => {
                 // It should be impossible for any input to get here,
                 // so panic rather than returning an error or pretending
@@ -145,7 +150,9 @@ impl ParseData for Core {
         match self.data {
             Data::Struct(Fields {
                 style: Style::Unit, ..
-            }) => panic!("Core::parse_field should not be called on unit"),
+            }) => {
+                panic!("Core::parse_field should not be called on unit")
+            }
             Data::Struct(Fields { ref mut fields, .. }) => {
                 fields.push(f);
                 Ok(())

--- a/core/src/options/input_field.rs
+++ b/core/src/options/input_field.rs
@@ -53,7 +53,12 @@ impl InputField {
     /// in the `Inherit` case.
     fn as_codegen_default(&self) -> Option<codegen::DefaultExpression<'_>> {
         self.default.as_ref().map(|expr| match *expr {
-            DefaultExpression::Explicit(ref path) => codegen::DefaultExpression::Explicit(path),
+            DefaultExpression::ExplicitPath(ref path) => {
+                codegen::DefaultExpression::ExplicitPath(path)
+            }
+            DefaultExpression::ExplicitClosure(ref closure) => {
+                codegen::DefaultExpression::ExplicitClosure(closure)
+            }
             DefaultExpression::Inherit => codegen::DefaultExpression::Inherit(&self.ident),
             DefaultExpression::Trait { span } => codegen::DefaultExpression::Trait { span },
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,8 @@
 //!   You can also use `#[darling(rename_all="...")]` at the struct or enum level to apply a casing rule to all fields or variants.
 //! * **Map function**: You can use `#[darling(map="path::to::function")]` to run code on a field before its stored in the struct.
 //! * **Default values**: You can use `#[darling(default)]` at the type or field level to use that type's default value to fill
-//!   in values not specified by the caller.
+//!   in values not specified by the caller. You can also set a custom default value by passing in a function path or a closure:
+//!   `#[darling(default = "path::to::function")]` or `#[darling(default = || get_default())]`.
 //! * **Skipped fields**: You can skip a variant or field using `#[darling(skip)]`. Fields marked with this will fall back to
 //!   `Default::default()` for their value, but you can override that with an explicit default or a value from the type-level default.
 //! * **Custom shorthand**: Use `#[darling(from_word = ...)]` on a struct or enum to override how a simple word is interpreted.

--- a/tests/defaults.rs
+++ b/tests/defaults.rs
@@ -12,8 +12,17 @@ mod foo {
 #[derive(FromDeriveInput)]
 #[darling(attributes(speak))]
 pub struct SpeakerOpts {
+    // path support
     #[darling(default = foo::bar::init)]
     first_word: String,
+    #[darling(default = "foo::bar::init")]
+    first_word_lit: String,
+
+    // closure support
+    #[darling(default = || "world".to_owned())]
+    second_word: String,
+    #[darling(default = r#"|| "world".to_owned()"#)]
+    second_word_lit: String,
 }
 
 #[test]
@@ -24,6 +33,9 @@ fn path_default() {
     .expect("Unit struct with no attrs should parse");
 
     assert_eq!(speaker.first_word, "hello");
+    assert_eq!(speaker.first_word_lit, "hello");
+    assert_eq!(speaker.second_word, "world");
+    assert_eq!(speaker.second_word_lit, "world");
 }
 
 /// Tests in this module capture the somewhat-confusing behavior observed when defaults


### PR DESCRIPTION
- E.g. `#[darling(default = || get_val())]`
- See https://github.com/TedDriggs/darling/issues/219#issuecomment-3308315497