### PR TITLE
Add empty `rustfmt.toml` to enforce default formatting

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,4 @@
+# This empty configuration file overrides any local user configuration,
+# ensuring formatting uniformity for all contributors.
+#
+# See https://github.com/rust-lang/rustfmt/blob/master/Configurations.md#configuring-rustfmt


### PR DESCRIPTION
Contributors may have a custom local `rustfmt.toml` on their machine. Having an empty `rustfmt.toml` in the repo overrides it, which ensures formatting uniformity.