### PR TITLE
docs: fix minor typo in top-level doc comment ('its' → 'it’s')

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //!
 //! * **Field renaming**: You can use `#[darling(rename="new_name")]` on a field to change the name Darling looks for.
 //!   You can also use `#[darling(rename_all="...")]` at the struct or enum level to apply a casing rule to all fields or variants.
-//! * **Map function**: You can use `#[darling(map="path::to::function")]` to run code on a field before its stored in the struct.
+//! * **Map function**: You can use `#[darling(map="path::to::function")]` to run code on a field before it's stored in the struct.
 //! * **Default values**: You can use `#[darling(default)]` at the type or field level to use that type's default value to fill
 //!   in values not specified by the caller. You can also set a custom default value by passing in a function path or a closure:
 //!   `#[darling(default = path::to::function)]` or `#[darling(default = || get_default())]`.


### PR DESCRIPTION
This PR fixes a minor grammatical error in the top-level library documentation comment.