### PR TITLE
Add default type parameter to `Result` type

### DIFF
--- a/core/src/error/mod.rs
+++ b/core/src/error/mod.rs
@@ -25,7 +25,7 @@ use crate::util::path_to_string;
 use self::kind::{ErrorKind, ErrorUnknownValue, UnknownValuePosition};
 
 /// An alias of `Result` specific to attribute parsing.
-pub type Result<T> = ::std::result::Result<T, Error>;
+pub type Result<T, E = Error> = ::std::result::Result<T, E>;
 
 /// An error encountered during attribute parsing.
 ///


### PR DESCRIPTION
This makes the `Result` type alias have a default Error type of `darling::Error`, but it allows specifying another Error type.

This is commonly done in Rust libraries because when you do `use darling::Result` and you just need to use a `Result` with another error type you can just do it, you don't need to go ahead and do `use std::result::Result` for that.