### PR TITLE
Add `darling::util::extract_option` helpers to extract `T` from `Option<T>`

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -24,5 +24,4 @@ syn = { version = "2.0.15", features = ["full", "extra-traits"] }
 strsim = { version = "0.11.1", optional = true }
 
 [dev-dependencies]
-darling = { path = ".." }
 serde_json = "1.0.140"

--- a/core/src/util/extract_option.rs
+++ b/core/src/util/extract_option.rs
@@ -32,6 +32,7 @@ use syn::{spanned::Spanned, Type};
 /// # Example
 ///
 /// ```
+/// # use darling_core as darling;
 /// use darling::util::extract_option;
 /// use quote::ToTokens;
 /// use syn::Type;
@@ -94,6 +95,7 @@ pub fn from_owned(ty: Type) -> Result<Type> {
 /// # Example
 ///
 /// ```
+/// # use darling_core as darling;
 /// use darling::util::extract_option;
 /// use quote::ToTokens;
 /// use syn::Type;
@@ -156,6 +158,7 @@ pub fn from_mut(ty: &mut Type) -> Result<&mut Type> {
 /// # Example
 ///
 /// ```
+/// # use darling_core as darling;
 /// use darling::util::extract_option;
 /// use quote::ToTokens;
 /// use syn::Type;


### PR DESCRIPTION
This PR creates `darling::util::extract_option` with 3 functions, for operating on `Type`, `&Type` and `&mut Type` 

```rust
pub fn from_owned(ty: Type) -> Result<syn::Type> 
```

I went with your idea, as well as having the functions return `Result` right away, so it can be nicely composed using the `?` operator

I considered using a macro to define the 3 functions, but I don't think it's worth it because people will use "goto definition"and these 3 functions are fairly simple so I think we can just copy-paste (also, each function is slightly different because of ownership requirements, so the macro would have a lot of edge cases)

Closes https://github.com/TedDriggs/darling/issues/396