### PR TITLE
Allow `clippy::needless_continue` in generated code

### DIFF
--- a/core/src/codegen/outer_from_impl.rs
+++ b/core/src/codegen/outer_from_impl.rs
@@ -29,6 +29,7 @@ pub trait OuterFromImpl<'a> {
         tokens.append_all(quote!(
             #[automatically_derived]
             #[allow(clippy::manual_unwrap_or_default)]
+            #[allow(clippy::needless_continue)]
             impl #impl_generics #trayt for #ty_ident #ty_generics
                 #where_clause
             {


### PR DESCRIPTION
Fixes #399

As described in the issue, since 1.92 clippy has a new lint, which lints `contine` statements which may not be needed. This change allows it for generated code, to prevent warnings in generated code.