### PR TITLE
Optimize `path_to_string`

### DIFF
--- a/core/src/codegen/attr_extractor.rs
+++ b/core/src/codegen/attr_extractor.rs
@@ -98,7 +98,7 @@ pub trait ExtractAttribute {
 
             for __attr in #attrs_accessor {
                 // Filter attributes based on name
-                match _darling::export::ToString::to_string(&__attr.path().clone().into_token_stream()).as_str() {
+                match _darling::util::path_to_string(__attr.path()).as_str() {
                     #parse_handled
                     #forward_unhandled
                 }

--- a/core/src/util/path_to_string.rs
+++ b/core/src/util/path_to_string.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 /// Transform Rust paths to a readable and comparable string.
 ///
 /// # Limitations
@@ -13,9 +15,16 @@
 pub fn path_to_string(path: &syn::Path) -> String {
     path.segments
         .iter()
-        .map(|s| s.ident.to_string())
-        .collect::<Vec<String>>()
-        .join("::")
+        // like `.intersperse("::")`, but that's not stable yet
+        .enumerate()
+        .flat_map(|(i, s)| {
+            if i == 0 {
+                [Cow::Borrowed(""), s.ident.to_string().into()]
+            } else {
+                [Cow::Borrowed("::"), s.ident.to_string().into()]
+            }
+        })
+        .collect()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
It's not necessary to allocate the `Vec`, we can just directly create the `String` via interspersing with `"::"`