### PR TITLE
Pass tokens that failed to parse as `Expr` to `FromMeta::from_verbatim`

### DIFF
--- a/core/src/ast/data/mod.rs
+++ b/core/src/ast/data/mod.rs
@@ -9,7 +9,7 @@ use crate::usage::{
 };
 use crate::{Error, FromField, FromVariant, Result};
 
-pub use nested_meta::NestedMeta;
+pub use nested_meta::{MetaNameValueInvalidExpr, NestedMeta};
 
 mod nested_meta;
 

--- a/examples/html.rs
+++ b/examples/html.rs
@@ -1,0 +1,47 @@
+//! This example shows how to parse completely arbitrary input (a self-closing HTML tag) -
+//! via implementing [`FromMeta::from_invalid_expr`]
+
+use darling::ast::MetaNameValueInvalidExpr;
+use syn::{Ident, Token};
+
+fn main() {
+    let input = quote::quote! {
+        #[args(tag = <br />, foo = 10)]
+        struct Input;
+    };
+    let input = syn::parse2::<syn::DeriveInput>(input).unwrap();
+    let input = <Input as darling::FromDeriveInput>::from_derive_input(&input).unwrap();
+
+    assert_eq!(
+        input.tag,
+        TagName(Ident::new("br", proc_macro2::Span::call_site()))
+    );
+    assert_eq!(input.foo, 10);
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct TagName(Ident);
+
+impl syn::parse::Parse for TagName {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        input.parse::<Token![<]>()?;
+        let tag_name = input.parse::<Ident>()?;
+        input.parse::<Token![/]>()?;
+        input.parse::<Token![>]>()?;
+
+        Ok(Self(tag_name))
+    }
+}
+
+impl darling::FromMeta for TagName {
+    fn from_invalid_expr(value: &MetaNameValueInvalidExpr) -> darling::Result<Self> {
+        syn::parse2(value.value.clone()).map_err(Into::into)
+    }
+}
+
+#[derive(darling::FromDeriveInput)]
+#[darling(attributes(args))]
+struct Input {
+    tag: TagName,
+    foo: usize,
+}


### PR DESCRIPTION
This PR adds a new `FromMeta::from_invalid_expr` which accepts an arbitrary `TokenStream` as an input. This can be used to parse arbitrary code that fails to parse as a `syn::Expr`. For example, this failed to parse previously:

```rust
#[method(vis = pub(crate))]
```

You used to have to use quotation marks for that:

```rust
#[method(vis = "pub(crate)")]
```

Because `pub(crate)` is not a valid expression. Now, it will call the `from_invalid_expr` method, passing it the `TokenStream` corresponding to the tokens `pub(crate)` because we failed to parse `pub(crate)` as an expression

Also, `syn::Type`, `syn::Type*`, `syn::Visibility` and `syn::WhereClause` don't require quotation marks anymore

Closes https://github.com/TedDriggs/darling/issues/378