### PR TITLE
Convert errors in Accumulator::handle

### DIFF
--- a/core/src/codegen/from_derive_impl.rs
+++ b/core/src/codegen/from_derive_impl.rs
@@ -93,7 +93,7 @@ impl ToTokens for FromDeriveInputImpl<'_> {
                 Some(p) => p.clone(),
                 None => parse_quote_spanned!(i.ty.span()=> _darling::export::TryFrom::try_from),
             })
-            .unwrap_or_else(|| parse_quote!(_darling::export::Ok));
+            .unwrap_or_else(|| parse_quote!(_darling::Result::Ok));
 
         let supports = self.supports;
         let validate_and_read_data = {

--- a/core/src/codegen/from_variant_impl.rs
+++ b/core/src/codegen/from_variant_impl.rs
@@ -64,7 +64,7 @@ impl ToTokens for FromVariantImpl<'_> {
                 Some(p) => p.clone(),
                 None => parse_quote_spanned!(i.ty.span()=> _darling::ast::Fields::try_from),
             })
-            .unwrap_or_else(|| parse_quote!(_darling::export::Ok));
+            .unwrap_or_else(|| parse_quote!(_darling::Result::Ok));
 
         let supports = self
             .supports

--- a/core/src/error/mod.rs
+++ b/core/src/error/mod.rs
@@ -828,12 +828,13 @@ impl Accumulator {
 
     /// Handles a possible error.
     ///
-    /// Returns a successful value as `Some`, or collects the error and returns `None`.
-    pub fn handle<T>(&mut self, result: Result<T>) -> Option<T> {
+    /// Returns a successful value as `Some`, or collects the error,
+    /// converts it to `darling::Error`, and returns `None`.
+    pub fn handle<T, E: Into<Error>>(&mut self, result: std::result::Result<T, E>) -> Option<T> {
         match result {
             Ok(y) => Some(y),
             Err(e) => {
-                self.push(e);
+                self.push(e.into());
                 None
             }
         }


### PR DESCRIPTION
@nik-rev @DCNick3 review is welcome

This makes for slightly more concise use of Accumulator::handle by removing the need to do error conversion at the call site.

This is a breaking change for callers who were already calling into on the error path. Two places in generated code were broken as a result of the change, so the first commit fixes those to avoid the error.

Fixes #252